### PR TITLE
Allow dynamic import for Node.js >=12.17 <13 || >=13.2

### DIFF
--- a/lib/rules/no-unsupported-features/es-syntax.js
+++ b/lib/rules/no-unsupported-features/es-syntax.js
@@ -6,7 +6,7 @@
 
 const { rules: esRules } = require("eslint-plugin-es")
 const { getInnermostScope } = require("eslint-utils")
-const { Range } = require("semver") //eslint-disable-line no-unused-vars
+const { Range } = require("semver")
 const getConfiguredNodeVersion = require("../../util/get-configured-node-version")
 const getSemverRange = require("../../util/get-semver-range")
 const mergeVisitorsInPlace = require("../../util/merge-visitors-in-place")
@@ -378,7 +378,7 @@ const features = {
         ruleId: "no-dynamic-import",
         cases: [
             {
-                supported: null,
+                supported: new Range(">=12.17 <13 || >=13.2"),
                 messageId: "no-dynamic-import",
             },
         ],
@@ -453,10 +453,15 @@ function defineVisitor(context, options) {
      * @returns {boolean} `true` if it's supporting.
      */
     function isNotSupportingVersion(aCase) {
-        return (
-            !aCase.supported ||
-            options.version.intersects(getSemverRange(`<${aCase.supported}`))
-        )
+        if (!aCase.supported) {
+            return true
+        }
+
+        if (aCase.supported instanceof Range) {
+            return !options.version.intersects(aCase.supported)
+        }
+
+        return options.version.intersects(getSemverRange(`<${aCase.supported}`))
     }
 
     /**
@@ -645,7 +650,7 @@ module.exports = {
             "no-bigint-property-names":
                 "Bigint literal property names are not supported yet.",
             "no-dynamic-import":
-                "'import()' expressions are not supported yet.",
+                "'import()' expressions are not supported until Node.js {{supported}}. The configured version range is '{{version}}'.",
             "no-optional-chaining":
                 "Optional chainings are not supported until Node.js {{supported}}. The configured version range is '{{version}}'.",
             "no-nullish-coalescing-operators":

--- a/tests/lib/rules/no-unsupported-features/es-syntax.js
+++ b/tests/lib/rules/no-unsupported-features/es-syntax.js
@@ -7,6 +7,7 @@
 const path = require("path")
 const { Linter, RuleTester } = require("eslint")
 const { builtin } = require("globals")
+const { Range } = require("semver")
 const rule = require("../../../../lib/rules/no-unsupported-features/es-syntax")
 
 const ES2020Supported = (() => {
@@ -2486,27 +2487,27 @@ ruleTester.run(
                     code: "obj.import(source)",
                     options: [{ version: "12.0.0" }],
                 },
-                {
+                ...["12.17.0", "13.2.0"].map(v => ({
                     code: "import(source)",
-                    options: [
-                        { version: "13.1.0", ignores: ["dynamicImport"] },
-                    ],
-                },
+                    options: [{ version: v }],
+                })),
             ],
             invalid: [
-                {
+                ...["12.16.0", "13.0.0", "13.1.0"].map(v => ({
                     code: "import(source)",
-                    options: [{ version: "13.3.0" }],
+                    options: [{ version: v }],
                     errors: [
                         {
                             messageId: "no-dynamic-import",
                             data: {
-                                supported: null,
-                                version: "13.3.0",
+                                supported: new Range(
+                                    ">=12.17 <13 || >=13.2"
+                                ).toString(),
+                                version: v,
                             },
                         },
                     ],
-                },
+                })),
             ],
         },
         {


### PR DESCRIPTION
<sup>(This PR was moved from https://github.com/mysticatea/eslint-plugin-node/pull/256 as that repository is currently unmaintained.)</sup>
## Summary
This attempts to resolve https://github.com/mysticatea/eslint-plugin-node/issues/250 by specifying the supported version for dynamic imports. Check the original PR for discussions I opened on the code around some of my changes.

## Changes
* Extend `case.supported` to support explicit `Range` instances
* Update error string for `no-dynamic-import`
* Update tests to check around those constraints