### PR TITLE
Make most variants of module.exports = { ... } fixable

### DIFF
--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -140,11 +140,7 @@ function getExportsNodes(scope) {
 }
 
 function getReplacementForProperty(property, sourceCode, isLast) {
-    if (
-        property.kind === "get" ||
-        property.shorthand ||
-        property.type === "SpreadElement"
-    ) {
+    if (property.kind === "get" || property.type === "SpreadElement") {
         // module.exports = { get foo() { ... } }
         // module.exports = { foo }
         // module.exports = { ...foo }

--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -149,8 +149,9 @@ function fixModuleExportsToExports(node, sourceCode, fixer) {
     ) {
         return []
     }
-    const replacements = []
-    for (const property of node.parent.right.properties) {
+    const statements = []
+    const properties = node.parent.right.properties
+    for (const [i, property] of properties.entries()) {
         if (
             property.kind === "get" ||
             property.shorthand ||
@@ -172,22 +173,32 @@ function fixModuleExportsToExports(node, sourceCode, fixer) {
                 fixedValue = `async ${fixedValue}`
             }
         }
+        const comments = sourceCode.getComments(property)
+        const lines = comments.leading.map(comment =>
+            sourceCode.getText(comment)
+        )
         if (property.key.type === "Literal" || property.computed) {
             // String or dynamic key:
             // module.exports = { [ ... ]: ... } or { "foo": ... }
-            replacements.push(
+            lines.push(
                 `exports[${sourceCode.getText(property.key)}] = ${fixedValue}`
             )
         } else if (property.key.type === "Identifier") {
             // Regular identifier:
             // module.exports = { foo: ... }
-            replacements.push(`exports.${property.key.name} = ${fixedValue}`)
+            lines.push(`exports.${property.key.name} = ${fixedValue};`)
         } else {
             // Some other unknown property type. Conservatively give up on fixing the whole thing.
             return []
         }
+        if (i === properties.length - 1) {
+            lines.push(
+                ...comments.trailing.map(comment => sourceCode.getText(comment))
+            )
+        }
+        statements.push(lines.join("\n"))
     }
-    return fixer.replaceText(node.parent, replacements.join(";\n\n"))
+    return fixer.replaceText(node.parent, statements.join("\n\n"))
 }
 
 module.exports = {

--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -175,7 +175,7 @@ function getReplacementForProperty(property, sourceCode) {
         lines.push(`exports.${property.key.name} = ${fixedValue};`)
     } else {
         // Some other unknown property type. Conservatively give up on fixing the whole thing.
-        return undefined
+        return null
     }
     lines.push(
         ...sourceCode
@@ -207,7 +207,7 @@ function fixModuleExports(node, sourceCode, fixer) {
         return fixer.replaceText(node, "exports")
     }
     if (!isModuleExportsObjectAssignment(node)) {
-        return undefined
+        return null
     }
     const statements = []
     const properties = node.parent.right.properties
@@ -217,7 +217,7 @@ function fixModuleExports(node, sourceCode, fixer) {
             statements.push(statement)
         } else {
             // No replacement available, give up on the whole thing
-            return undefined
+            return null
         }
     }
     return fixer.replaceText(node.parent, statements.join("\n\n"))

--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -181,7 +181,7 @@ function fixModuleExportsToExports(node, sourceCode, fixer) {
             // String or dynamic key:
             // module.exports = { [ ... ]: ... } or { "foo": ... }
             lines.push(
-                `exports[${sourceCode.getText(property.key)}] = ${fixedValue}`
+                `exports[${sourceCode.getText(property.key)}] = ${fixedValue};`
             )
         } else if (property.key.type === "Identifier") {
             // Regular identifier:

--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -139,7 +139,7 @@ function getExportsNodes(scope) {
     return variable.references.map(reference => reference.identifier)
 }
 
-function fixModuleExportsToExports(node, sourceCode, fixer) {
+function fixModuleExports(node, sourceCode, fixer) {
     // Make sure that we're looking at a top level module.exports = { ... }
     if (
         node.parent.type !== "AssignmentExpression" ||
@@ -147,7 +147,11 @@ function fixModuleExportsToExports(node, sourceCode, fixer) {
         node.parent.parent.parent.type !== "Program" ||
         node.parent.right.type !== "ObjectExpression"
     ) {
-        return []
+        if (node.parent.type === "MemberExpression" && node.parent.object === node) {
+            return fixer.replaceText(node, "exports")
+        } else {
+            return []
+        }
     }
     const statements = []
     const properties = node.parent.right.properties
@@ -317,11 +321,7 @@ module.exports = {
                     message:
                         "Unexpected access to 'module.exports'. Use 'exports' instead.",
                     fix(fixer) {
-                        return fixModuleExportsToExports(
-                            node,
-                            sourceCode,
-                            fixer
-                        )
+                        return fixModuleExports(node, sourceCode, fixer)
                     },
                 })
             }

--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -203,7 +203,7 @@ function fixModuleExports(node, sourceCode, fixer) {
         return fixer.replaceText(node, "exports")
     }
     if (!isModuleExportsObjectAssignment(node)) {
-        return []
+        return undefined
     }
     const statements = []
     const properties = node.parent.right.properties
@@ -217,7 +217,7 @@ function fixModuleExports(node, sourceCode, fixer) {
             statements.push(statement)
         } else {
             // No replacement available, give up on the whole thing
-            return []
+            return undefined
         }
     }
     return fixer.replaceText(node.parent, statements.join("\n\n"))

--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -165,7 +165,9 @@ function fixModuleExportsToExports(node, sourceCode, fixer) {
         }
         let fixedValue = sourceCode.getText(property.value)
         if (property.method) {
-            fixedValue = `function ${fixedValue}`
+            fixedValue = `function${
+                property.value.generator ? "*" : ""
+            } ${fixedValue}`
             if (property.value.async) {
                 fixedValue = `async ${fixedValue}`
             }

--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -139,6 +139,55 @@ function getExportsNodes(scope) {
     return variable.references.map(reference => reference.identifier)
 }
 
+function fixModuleExportsToExports(node, sourceCode, fixer) {
+    // Make sure that we're looking at a top level module.exports = { ... }
+    if (
+        node.parent.type !== "AssignmentExpression" ||
+        node.parent.parent.type !== "ExpressionStatement" ||
+        node.parent.parent.parent.type !== "Program" ||
+        node.parent.right.type !== "ObjectExpression"
+    ) {
+        return []
+    }
+    const replacements = []
+    for (const property of node.parent.right.properties) {
+        if (
+            property.kind === "get" ||
+            property.shorthand ||
+            property.type === "SpreadElement"
+        ) {
+            // module.exports = { get foo() { ... } }
+            // module.exports = { foo }
+            // module.exports = { ...foo }
+            // We don't have a similarly nice syntax for adding these directly
+            // on the exports object. Give up on fixing the whole thing.
+            return []
+        }
+        let fixedValue = sourceCode.getText(property.value)
+        if (property.method) {
+            fixedValue = `function ${fixedValue}`
+            if (property.value.async) {
+                fixedValue = `async ${fixedValue}`
+            }
+        }
+        if (property.key.type === "Literal" || property.computed) {
+            // String or dynamic key:
+            // module.exports = { [ ... ]: ... } or { "foo": ... }
+            replacements.push(
+                `exports[${sourceCode.getText(property.key)}] = ${fixedValue}`
+            )
+        } else if (property.key.type === "Identifier") {
+            // Regular identifier:
+            // module.exports = { foo: ... }
+            replacements.push(`exports.${property.key.name} = ${fixedValue}`)
+        } else {
+            // Some other unknown property type. Conservatively give up on fixing the whole thing.
+            return []
+        }
+    }
+    return fixer.replaceText(node.parent, replacements.join(";\n\n"))
+}
+
 module.exports = {
     meta: {
         docs: {
@@ -149,7 +198,7 @@ module.exports = {
                 "https://github.com/mysticatea/eslint-plugin-node/blob/v11.0.0/docs/rules/exports-style.md",
         },
         type: "suggestion",
-        fixable: null,
+        fixable: "code",
         schema: [
             {
                 //
@@ -254,6 +303,13 @@ module.exports = {
                     loc: getLocation(node),
                     message:
                         "Unexpected access to 'module.exports'. Use 'exports' instead.",
+                    fix(fixer) {
+                        return fixModuleExportsToExports(
+                            node,
+                            sourceCode,
+                            fixer
+                        )
+                    },
                 })
             }
 

--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -140,14 +140,17 @@ function getExportsNodes(scope) {
 }
 
 function getReplacementForProperty(property, sourceCode) {
-    if (property.kind === "get" || property.type === "SpreadElement") {
-        // module.exports = { get foo() { ... } }
-        // module.exports = { foo }
-        // module.exports = { ...foo }
-        // We don't have a similarly nice syntax for adding these directly
-        // on the exports object. Give up on fixing the whole thing.
-        return undefined
+    if (property.type !== "Property" || property.kind !== "init") {
+        // We don't have a nice syntax for adding these directly on the exports object. Give up on fixing the whole thing:
+        // property.kind === 'get':
+        //   module.exports = { get foo() { ... } }
+        // property.kind === 'set':
+        //   module.exports = { set foo() { ... } }
+        // property.type === 'SpreadElement':
+        //   module.exports = { ...foo }
+        return null
     }
+
     let fixedValue = sourceCode.getText(property.value)
     if (property.method) {
         fixedValue = `function${

--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -139,68 +139,83 @@ function getExportsNodes(scope) {
     return variable.references.map(reference => reference.identifier)
 }
 
+function getReplacementForProperty(property, sourceCode, isLast) {
+    if (
+        property.kind === "get" ||
+        property.shorthand ||
+        property.type === "SpreadElement"
+    ) {
+        // module.exports = { get foo() { ... } }
+        // module.exports = { foo }
+        // module.exports = { ...foo }
+        // We don't have a similarly nice syntax for adding these directly
+        // on the exports object. Give up on fixing the whole thing.
+        return undefined
+    }
+    let fixedValue = sourceCode.getText(property.value)
+    if (property.method) {
+        fixedValue = `function${
+            property.value.generator ? "*" : ""
+        } ${fixedValue}`
+        if (property.value.async) {
+            fixedValue = `async ${fixedValue}`
+        }
+    }
+    const comments = sourceCode.getComments(property)
+    const lines = comments.leading.map(comment => sourceCode.getText(comment))
+    if (property.key.type === "Literal" || property.computed) {
+        // String or dynamic key:
+        // module.exports = { [ ... ]: ... } or { "foo": ... }
+        lines.push(
+            `exports[${sourceCode.getText(property.key)}] = ${fixedValue};`
+        )
+    } else if (property.key.type === "Identifier") {
+        // Regular identifier:
+        // module.exports = { foo: ... }
+        lines.push(`exports.${property.key.name} = ${fixedValue};`)
+    } else {
+        // Some other unknown property type. Conservatively give up on fixing the whole thing.
+        return undefined
+    }
+    if (isLast) {
+        lines.push(
+            ...comments.trailing.map(comment => sourceCode.getText(comment))
+        )
+    }
+    return lines.join("\n")
+}
+
 function fixModuleExports(node, sourceCode, fixer) {
-    // Make sure that we're looking at a top level module.exports = { ... }
+    // Check for module.exports.foo or module.exports.bar reference or assignment
+    if (
+        node.parent.type === "MemberExpression" &&
+        node.parent.object === node
+    ) {
+        return fixer.replaceText(node, "exports")
+    }
+    // Make sure we're looking at a top level module.exports = { ... }
     if (
         node.parent.type !== "AssignmentExpression" ||
         node.parent.parent.type !== "ExpressionStatement" ||
         node.parent.parent.parent.type !== "Program" ||
         node.parent.right.type !== "ObjectExpression"
     ) {
-        if (node.parent.type === "MemberExpression" && node.parent.object === node) {
-            return fixer.replaceText(node, "exports")
-        } else {
-            return []
-        }
+        return []
     }
     const statements = []
     const properties = node.parent.right.properties
     for (const [i, property] of properties.entries()) {
-        if (
-            property.kind === "get" ||
-            property.shorthand ||
-            property.type === "SpreadElement"
-        ) {
-            // module.exports = { get foo() { ... } }
-            // module.exports = { foo }
-            // module.exports = { ...foo }
-            // We don't have a similarly nice syntax for adding these directly
-            // on the exports object. Give up on fixing the whole thing.
-            return []
-        }
-        let fixedValue = sourceCode.getText(property.value)
-        if (property.method) {
-            fixedValue = `function${
-                property.value.generator ? "*" : ""
-            } ${fixedValue}`
-            if (property.value.async) {
-                fixedValue = `async ${fixedValue}`
-            }
-        }
-        const comments = sourceCode.getComments(property)
-        const lines = comments.leading.map(comment =>
-            sourceCode.getText(comment)
+        const statement = getReplacementForProperty(
+            property,
+            sourceCode,
+            i === properties.length - 1
         )
-        if (property.key.type === "Literal" || property.computed) {
-            // String or dynamic key:
-            // module.exports = { [ ... ]: ... } or { "foo": ... }
-            lines.push(
-                `exports[${sourceCode.getText(property.key)}] = ${fixedValue};`
-            )
-        } else if (property.key.type === "Identifier") {
-            // Regular identifier:
-            // module.exports = { foo: ... }
-            lines.push(`exports.${property.key.name} = ${fixedValue};`)
+        if (statement) {
+            statements.push(statement)
         } else {
-            // Some other unknown property type. Conservatively give up on fixing the whole thing.
+            // No replacement available, give up on the whole thing
             return []
         }
-        if (i === properties.length - 1) {
-            lines.push(
-                ...comments.trailing.map(comment => sourceCode.getText(comment))
-            )
-        }
-        statements.push(lines.join("\n"))
     }
     return fixer.replaceText(node.parent, statements.join("\n\n"))
 }

--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -139,7 +139,7 @@ function getExportsNodes(scope) {
     return variable.references.map(reference => reference.identifier)
 }
 
-function getReplacementForProperty(property, sourceCode, isLast) {
+function getReplacementForProperty(property, sourceCode) {
     if (property.kind === "get" || property.type === "SpreadElement") {
         // module.exports = { get foo() { ... } }
         // module.exports = { foo }
@@ -173,11 +173,7 @@ function getReplacementForProperty(property, sourceCode, isLast) {
         // Some other unknown property type. Conservatively give up on fixing the whole thing.
         return undefined
     }
-    if (isLast) {
-        lines.push(
-            ...comments.trailing.map(comment => sourceCode.getText(comment))
-        )
-    }
+    lines.push(...comments.trailing.map(comment => sourceCode.getText(comment)))
     return lines.join("\n")
 }
 
@@ -207,12 +203,8 @@ function fixModuleExports(node, sourceCode, fixer) {
     }
     const statements = []
     const properties = node.parent.right.properties
-    for (const [i, property] of properties.entries()) {
-        const statement = getReplacementForProperty(
-            property,
-            sourceCode,
-            i === properties.length - 1
-        )
+    for (const property of properties) {
+        const statement = getReplacementForProperty(property, sourceCode)
         if (statement) {
             statements.push(statement)
         } else {

--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -157,8 +157,9 @@ function getReplacementForProperty(property, sourceCode) {
             fixedValue = `async ${fixedValue}`
         }
     }
-    const comments = sourceCode.getComments(property)
-    const lines = comments.leading.map(comment => sourceCode.getText(comment))
+    const lines = sourceCode
+        .getCommentsBefore(property)
+        .map(comment => sourceCode.getText(comment))
     if (property.key.type === "Literal" || property.computed) {
         // String or dynamic key:
         // module.exports = { [ ... ]: ... } or { "foo": ... }
@@ -173,7 +174,11 @@ function getReplacementForProperty(property, sourceCode) {
         // Some other unknown property type. Conservatively give up on fixing the whole thing.
         return undefined
     }
-    lines.push(...comments.trailing.map(comment => sourceCode.getText(comment)))
+    lines.push(
+        ...sourceCode
+            .getCommentsAfter(property)
+            .map(comment => sourceCode.getText(comment))
+    )
     return lines.join("\n")
 }
 

--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -181,21 +181,28 @@ function getReplacementForProperty(property, sourceCode, isLast) {
     return lines.join("\n")
 }
 
+// Check for a top level module.exports = { ... }
+function isModuleExportsObjectAssignment(node) {
+    return (
+        node.parent.type === "AssignmentExpression" &&
+        node.parent.parent.type === "ExpressionStatement" &&
+        node.parent.parent.parent.type === "Program" &&
+        node.parent.right.type === "ObjectExpression"
+    )
+}
+
+// Check for module.exports.foo or module.exports.bar reference or assignment
+function isModuleExportsReference(node) {
+    return (
+        node.parent.type === "MemberExpression" && node.parent.object === node
+    )
+}
+
 function fixModuleExports(node, sourceCode, fixer) {
-    // Check for module.exports.foo or module.exports.bar reference or assignment
-    if (
-        node.parent.type === "MemberExpression" &&
-        node.parent.object === node
-    ) {
+    if (isModuleExportsReference(node)) {
         return fixer.replaceText(node, "exports")
     }
-    // Make sure we're looking at a top level module.exports = { ... }
-    if (
-        node.parent.type !== "AssignmentExpression" ||
-        node.parent.parent.type !== "ExpressionStatement" ||
-        node.parent.parent.parent.type !== "Program" ||
-        node.parent.right.type !== "ObjectExpression"
-    ) {
+    if (!isModuleExportsObjectAssignment(node)) {
         return []
     }
     const statements = []

--- a/tests/lib/rules/exports-style.js
+++ b/tests/lib/rules/exports-style.js
@@ -147,7 +147,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "module.exports = {foo: 1}",
-            output: "exports.foo = 1",
+            output: "exports.foo = 1;",
             options: ["exports"],
             globals: { module: false, exports: true },
             errors: [
@@ -165,7 +165,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "module.exports = { a: 1 }",
-            output: "exports.a = 1",
+            output: "exports.a = 1;",
             options: ["exports"],
             globals: { module: false, exports: true },
             errors: [
@@ -174,7 +174,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "module.exports = { a: 1, b: 2 }",
-            output: "exports.a = 1;\n\nexports.b = 2",
+            output: "exports.a = 1;\n\nexports.b = 2;",
             options: ["exports"],
             globals: { module: false, exports: true },
             errors: [
@@ -223,7 +223,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "module.exports = { ['a' + 'b']: 1 }",
-            output: "exports['a' + 'b'] = 1",
+            output: "exports['a' + 'b'] = 1;",
             options: ["exports"],
             parserOptions: { ecmaVersion: 6 },
             globals: { module: false, exports: true },
@@ -233,7 +233,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "module.exports = { 'foo': 1 }",
-            output: "exports['foo'] = 1",
+            output: "exports['foo'] = 1;",
             options: ["exports"],
             parserOptions: { ecmaVersion: 6 },
             globals: { module: false, exports: true },
@@ -243,7 +243,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "module.exports = { foo(a) {} }",
-            output: "exports.foo = function (a) {}",
+            output: "exports.foo = function (a) {};",
             options: ["exports"],
             parserOptions: { ecmaVersion: 8 },
             globals: { module: false, exports: true },
@@ -253,7 +253,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "module.exports = { *foo(a) {} }",
-            output: "exports.foo = function* (a) {}",
+            output: "exports.foo = function* (a) {};",
             options: ["exports"],
             parserOptions: { ecmaVersion: 6 },
             globals: { module: false, exports: true },
@@ -263,7 +263,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "module.exports = { async foo(a) {} }",
-            output: "exports.foo = async function (a) {}",
+            output: "exports.foo = async function (a) {};",
             options: ["exports"],
             parserOptions: { ecmaVersion: 8 },
             globals: { module: false, exports: true },

--- a/tests/lib/rules/exports-style.js
+++ b/tests/lib/rules/exports-style.js
@@ -156,7 +156,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "module.exports.foo = 1",
-            output: null,
+            output: "exports.foo = 1",
             options: ["exports"],
             globals: { module: false, exports: true },
             errors: [
@@ -277,6 +277,27 @@ new RuleTester().run("exports-style", rule, {
             parserOptions: { ecmaVersion: 8 },
             globals: { module: false, exports: true },
             errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+            ],
+        },
+        {
+            code: "module.exports.foo()",
+            output: "exports.foo()",
+            options: ["exports"],
+            parserOptions: { ecmaVersion: 8 },
+            globals: { module: false, exports: true },
+            errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+            ],
+        },
+        {
+            code: "a = module.exports.foo + module.exports['bar']",
+            output: "a = exports.foo + exports['bar']",
+            options: ["exports"],
+            parserOptions: { ecmaVersion: 8 },
+            globals: { module: false, exports: true },
+            errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
                 "Unexpected access to 'module.exports'. Use 'exports' instead.",
             ],
         },

--- a/tests/lib/rules/exports-style.js
+++ b/tests/lib/rules/exports-style.js
@@ -193,6 +193,15 @@ new RuleTester().run("exports-style", rule, {
             ],
         },
         {
+            code: "foo(module.exports = {foo: 1})",
+            output: null,
+            options: ["exports"],
+            globals: { module: false, exports: true },
+            errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+            ],
+        },
+        {
             code: "module.exports = { get a() {} }",
             output: null,
             options: ["exports"],

--- a/tests/lib/rules/exports-style.js
+++ b/tests/lib/rules/exports-style.js
@@ -202,7 +202,36 @@ new RuleTester().run("exports-style", rule, {
             ],
         },
         {
+            code:
+                "if(foo){ module.exports = { foo: 1};} else { module.exports = {foo: 2};}",
+            output: null,
+            options: ["exports"],
+            globals: { module: false, exports: true },
+            errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+            ],
+        },
+        {
+            code: "function bar() { module.exports = { foo: 1 }; }",
+            output: null,
+            options: ["exports"],
+            globals: { module: false, exports: true },
+            errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+            ],
+        },
+        {
             code: "module.exports = { get a() {} }",
+            output: null,
+            options: ["exports"],
+            globals: { module: false, exports: true },
+            errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+            ],
+        },
+        {
+            code: "module.exports = { set a(a) {} }",
             output: null,
             options: ["exports"],
             globals: { module: false, exports: true },

--- a/tests/lib/rules/exports-style.js
+++ b/tests/lib/rules/exports-style.js
@@ -241,6 +241,16 @@ new RuleTester().run("exports-style", rule, {
             ],
         },
         {
+            code: "module.exports = { *foo(a) {} }",
+            output: "exports.foo = function* (a) {}",
+            options: ["exports"],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { module: false, exports: true },
+            errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+            ],
+        },
+        {
             code: "module.exports = { async foo(a) {} }",
             output: "exports.foo = async function (a) {}",
             options: ["exports"],

--- a/tests/lib/rules/exports-style.js
+++ b/tests/lib/rules/exports-style.js
@@ -182,6 +182,17 @@ new RuleTester().run("exports-style", rule, {
             ],
         },
         {
+            code:
+                "module.exports = { // before a\na: 1, // between a and b\nb: 2 // after b\n}",
+            output:
+                "// before a\nexports.a = 1;\n\n// between a and b\nexports.b = 2;\n// after b",
+            options: ["exports"],
+            globals: { module: false, exports: true },
+            errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+            ],
+        },
+        {
             code: "module.exports = { get a() {} }",
             output: null,
             options: ["exports"],

--- a/tests/lib/rules/exports-style.js
+++ b/tests/lib/rules/exports-style.js
@@ -68,6 +68,7 @@ new RuleTester().run("exports-style", rule, {
     invalid: [
         {
             code: "exports = {foo: 1}",
+            output: null,
             globals: { module: false, exports: true },
             errors: [
                 "Unexpected access to 'exports'. Use 'module.exports' instead.",
@@ -75,6 +76,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "exports.foo = 1",
+            output: null,
             globals: { module: false, exports: true },
             errors: [
                 "Unexpected access to 'exports'. Use 'module.exports' instead.",
@@ -82,6 +84,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "module.exports = exports = {foo: 1}",
+            output: null,
             globals: { module: false, exports: true },
             errors: [
                 "Unexpected access to 'exports'. Use 'module.exports' instead.",
@@ -89,6 +92,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "exports = module.exports = {foo: 1}",
+            output: null,
             globals: { module: false, exports: true },
             errors: [
                 "Unexpected access to 'exports'. Use 'module.exports' instead.",
@@ -97,6 +101,7 @@ new RuleTester().run("exports-style", rule, {
 
         {
             code: "exports = {foo: 1}",
+            output: null,
             options: ["module.exports"],
             globals: { module: false, exports: true },
             errors: [
@@ -105,6 +110,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "exports.foo = 1",
+            output: null,
             options: ["module.exports"],
             globals: { module: false, exports: true },
             errors: [
@@ -113,6 +119,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "module.exports = exports = {foo: 1}",
+            output: null,
             options: ["module.exports"],
             globals: { module: false, exports: true },
             errors: [
@@ -121,6 +128,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "exports = module.exports = {foo: 1}",
+            output: null,
             options: ["module.exports"],
             globals: { module: false, exports: true },
             errors: [
@@ -130,6 +138,7 @@ new RuleTester().run("exports-style", rule, {
 
         {
             code: "exports = {foo: 1}",
+            output: null,
             options: ["exports"],
             globals: { module: false, exports: true },
             errors: [
@@ -138,6 +147,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "module.exports = {foo: 1}",
+            output: "exports.foo = 1",
             options: ["exports"],
             globals: { module: false, exports: true },
             errors: [
@@ -146,6 +156,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "module.exports.foo = 1",
+            output: null,
             options: ["exports"],
             globals: { module: false, exports: true },
             errors: [
@@ -153,7 +164,95 @@ new RuleTester().run("exports-style", rule, {
             ],
         },
         {
+            code: "module.exports = { a: 1 }",
+            output: "exports.a = 1",
+            options: ["exports"],
+            globals: { module: false, exports: true },
+            errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+            ],
+        },
+        {
+            code: "module.exports = { a: 1, b: 2 }",
+            output: "exports.a = 1;\n\nexports.b = 2",
+            options: ["exports"],
+            globals: { module: false, exports: true },
+            errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+            ],
+        },
+        {
+            code: "module.exports = { get a() {} }",
+            output: null,
+            options: ["exports"],
+            globals: { module: false, exports: true },
+            errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+            ],
+        },
+        {
+            code: "module.exports = { a }",
+            output: null,
+            options: ["exports"],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { module: false, exports: true },
+            errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+            ],
+        },
+        {
+            code: "module.exports = { ...a }",
+            output: null,
+            options: ["exports"],
+            parserOptions: { ecmaVersion: 9 },
+            globals: { module: false, exports: true },
+            errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+            ],
+        },
+        {
+            code: "module.exports = { ['a' + 'b']: 1 }",
+            output: "exports['a' + 'b'] = 1",
+            options: ["exports"],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { module: false, exports: true },
+            errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+            ],
+        },
+        {
+            code: "module.exports = { 'foo': 1 }",
+            output: "exports['foo'] = 1",
+            options: ["exports"],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { module: false, exports: true },
+            errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+            ],
+        },
+        {
+            code: "module.exports = { foo(a) {} }",
+            output: "exports.foo = function (a) {}",
+            options: ["exports"],
+            parserOptions: { ecmaVersion: 8 },
+            globals: { module: false, exports: true },
+            errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+            ],
+        },
+        {
+            code: "module.exports = { async foo(a) {} }",
+            output: "exports.foo = async function (a) {}",
+            options: ["exports"],
+            parserOptions: { ecmaVersion: 8 },
+            globals: { module: false, exports: true },
+            errors: [
+                "Unexpected access to 'module.exports'. Use 'exports' instead.",
+            ],
+        },
+        {
             code: "module.exports = exports = {foo: 1}",
+            output: null,
             options: ["exports"],
             globals: { module: false, exports: true },
             errors: [
@@ -163,6 +262,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "exports = module.exports = {foo: 1}",
+            output: null,
             options: ["exports"],
             globals: { module: false, exports: true },
             errors: [
@@ -172,6 +272,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "module.exports = exports = {foo: 1}; exports = obj",
+            output: null,
             options: ["exports", { allowBatchAssign: true }],
             globals: { module: false, exports: true },
             errors: [
@@ -180,6 +281,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "exports = module.exports = {foo: 1}; exports = obj",
+            output: null,
             options: ["exports", { allowBatchAssign: true }],
             globals: { module: false, exports: true },
             errors: [

--- a/tests/lib/rules/exports-style.js
+++ b/tests/lib/rules/exports-style.js
@@ -212,7 +212,7 @@ new RuleTester().run("exports-style", rule, {
         },
         {
             code: "module.exports = { a }",
-            output: null,
+            output: "exports.a = a;",
             options: ["exports"],
             parserOptions: { ecmaVersion: 6 },
             globals: { module: false, exports: true },


### PR DESCRIPTION
This is https://github.com/mysticatea/eslint-plugin-node/pull/208 against your fork now that `eslint-plugin-node` is unmaintained and `eslint-plugin-n` is being used by `eslint-config-standard` 😇 

It got reviewed by the original author, who then disappeared before merging it.