### PR TITLE
default mapping of source .ts import of unspecified extension should be  .js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /node_modules
 /test.js
 .eslintcache
+.vscode

--- a/lib/util/map-typescript-extension.js
+++ b/lib/util/map-typescript-extension.js
@@ -4,6 +4,7 @@ const path = require("path")
 const isTypescript = require("../util/is-typescript")
 
 const mapping = {
+    "": ".js", // default empty extension will map to js
     ".ts": ".js",
     ".cts": ".cjs",
     ".mts": ".mjs",

--- a/tests/lib/rules/file-extension-in-import.js
+++ b/tests/lib/rules/file-extension-in-import.js
@@ -75,6 +75,10 @@ new RuleTester({
         },
         {
             filename: fixture("test.ts"),
+            code: "import './a.js'",
+        },
+        {
+            filename: fixture("test.ts"),
             code: "import './d.js'",
         },
         {
@@ -143,6 +147,18 @@ new RuleTester({
             filename: fixture("test.js"),
             code: "import './a'",
             output: "import './a.js'",
+            errors: [{ messageId: "requireExt", data: { ext: ".js" } }],
+        },
+        {
+            filename: fixture("test.ts"),
+            code: "import './a'",
+            output: "import './a.js'",
+            errors: [{ messageId: "requireExt", data: { ext: ".js" } }],
+        },
+        {
+            filename: fixture("test.ts"),
+            code: "import './d'",
+            output: "import './d.js'",
             errors: [{ messageId: "requireExt", data: { ext: ".js" } }],
         },
         {


### PR DESCRIPTION
Closes #28 

Thanks @calebeby for the identification.  It was my fault for not supplying enough tests in the original PR #20.

@aladdin-add this should be released as an immediate hotfix/patch.  Thank you