### PR TITLE
feat(no-sync)!: move `ts-declaration-location` to `peerDependencies`

### DIFF
--- a/docs/rules/no-sync.md
+++ b/docs/rules/no-sync.md
@@ -79,6 +79,13 @@ Examples of **correct** code for this rule with the `{ ignores: ['readFileSync']
 fs.readFileSync(somePath);
 ```
 
+> [!WARNING]
+> Advanced `ignores` options (object specifiers) require TypeScript and the [`ts-declaration-location`](https://www.npmjs.com/package/ts-declaration-location) package. This package is an **optional peer dependency** for the `n/no-sync` rule. If you want to use advanced TypeScript-based ignores, please install it in your project:
+>
+> ```sh
+> npm install --save-dev ts-declaration-location
+> ```
+
 ##### Advanced (TypeScript only)
 
 You can provide a list of specifiers to ignore. Specifiers are typed as follows:
@@ -101,6 +108,9 @@ type Specifier =
     name?: string[];
   }
 ```
+
+> [!NOTE]
+> To use advanced TypeScript-based ignores, you must have `ts-declaration-location` installed as a dependency in your project.
 
 ###### From a file
 

--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -8,14 +8,6 @@ let typeMatchesSpecifier =
     /** @type {import('ts-declaration-location').default | undefined} */
     (undefined)
 
-try {
-    typeMatchesSpecifier =
-        /** @type {import('ts-declaration-location').default} */ (
-            /** @type {unknown} */ (require("ts-declaration-location"))
-        )
-
-    // eslint-disable-next-line no-empty -- Deliberately left empty.
-} catch {}
 const getTypeOfNode = require("../util/get-type-of-node")
 const getParserServices = require("../util/get-parser-services")
 const getFullTypeName = require("../util/get-full-type-name")
@@ -124,6 +116,27 @@ module.exports = {
         const selector = options.allowAtRootLevel
             ? selectors.map(selector => `:function ${selector}`)
             : selectors
+
+        const hasAdvancedIgnores = ignores.some(
+            ignore => typeof ignore !== "string"
+        )
+
+        // Only require `ts-declaration-location` if needed and not already required.
+        if (hasAdvancedIgnores) {
+            try {
+                typeMatchesSpecifier ||=
+                    /** @type {import('ts-declaration-location').default} */ (
+                        /** @type {unknown} */ (
+                            require("ts-declaration-location")
+                        )
+                    )
+            } catch {
+                throw new Error(
+                    'ts-declaration-location not available. Rule "n/no-sync" is configured to use "ignores" option with a non-string value. This requires ts-declaration-location to be available.'
+                )
+            }
+        }
+
         return {
             /**
              * @param {import('estree').Identifier & {parent: import('estree').Node}} node
@@ -160,12 +173,6 @@ module.exports = {
                         )
                     }
 
-                    if (typeMatchesSpecifier === undefined) {
-                        throw new Error(
-                            'ts-declaration-location not available. Rule "n/no-sync" is configured to use "ignores" option with a non-string value. This requires ts-declaration-location to be available.'
-                        )
-                    }
-
                     type =
                         type === undefined
                             ? getTypeOfNode(node, parserServices)
@@ -177,7 +184,7 @@ module.exports = {
                             : fullName
 
                     if (
-                        typeMatchesSpecifier(
+                        typeMatchesSpecifier?.(
                             parserServices.program,
                             ignore,
                             type

--- a/lib/util/get-full-type-name.js
+++ b/lib/util/get-full-type-name.js
@@ -2,7 +2,6 @@
 
 const ts = (() => {
     try {
-        // eslint-disable-next-line n/no-unpublished-require
         return require("typescript")
     } catch {
         return null

--- a/package.json
+++ b/package.json
@@ -14,7 +14,17 @@
         "types/index.d.ts"
     ],
     "peerDependencies": {
-        "eslint": ">=8.23.0"
+        "eslint": ">=8.23.0",
+        "ts-declaration-location": "^1.0.6",
+        "typescript": "^5.0.0"
+    },
+    "peerDependenciesMeta": {
+        "ts-declaration-location": {
+            "optional": true
+        },
+        "typescript": {
+            "optional": true
+        }
     },
     "dependencies": {
         "@eslint-community/eslint-utils": "^4.5.0",
@@ -24,8 +34,7 @@
         "globals": "^15.11.0",
         "globrex": "^0.1.2",
         "ignore": "^5.3.2",
-        "semver": "^7.6.3",
-        "ts-declaration-location": "^1.0.6"
+        "semver": "^7.6.3"
     },
     "devDependencies": {
         "@eslint/js": "^9.14.0",
@@ -52,6 +61,8 @@
         "punycode": "^2.3.1",
         "release-it": "^17.10.0",
         "rimraf": "^5.0.10",
+        "sinon": "^21.0.0",
+        "ts-declaration-location": "^1.0.6",
         "ts-ignore-import": "^4.0.1",
         "type-fest": "^4.26.1",
         "typescript": "~5.6"

--- a/tests/lib/rules/no-sync.js
+++ b/tests/lib/rules/no-sync.js
@@ -5,7 +5,10 @@
 "use strict"
 
 const { RuleTester, TsRuleTester } = require("#test-helpers")
+const Module = require("node:module")
+const assert = require("node:assert")
 const rule = require("../../../lib/rules/no-sync")
+const sinon = require("sinon")
 
 new RuleTester().run("no-sync", rule, {
     valid: [
@@ -318,4 +321,163 @@ fooSync();
             ],
         },
     ],
+})
+
+describe("no-sync rule with missing dependencies", () => {
+    const originalRequire = module.require
+    let mockRequire
+    let originalModules = {}
+
+    /**
+     * Helper function to mock a module.
+     * - Assigns a module object to `require.cache` with the provided mock exports to prevent TypeScript errors when the module is required, as TypeScript expects the module to exist in the cache with an 'exports' property.
+     *
+     * @param {string} modulePath - The path to the module.
+     * @param {*} mockExports - The mock exports to use.
+     */
+    function mockModule(modulePath, mockExports) {
+        const resolvedPath = require.resolve(modulePath)
+
+        // Store original module if not already stored.
+        if (!originalModules[resolvedPath] && require.cache[resolvedPath]) {
+            originalModules[resolvedPath] = require.cache[resolvedPath]
+        }
+
+        require.cache[resolvedPath] = { exports: mockExports }
+    }
+
+    /**
+     * Helper to test rule behavior with missing dependencies.
+     * - Sets mocks for each dependency based on options.
+     *
+     * @param {object} options - Test options.
+     * @param {boolean} options.mockTsDeclarationLocation - Whether to mock `ts-declaration-location` as missing.
+     * @param {boolean} options.mockTypeScriptServices - Whether to mock TypeScript services as missing.
+     * @param {RegExp} options.expectedError - The expected error message pattern.
+     */
+    function testWithMissingDependency(options) {
+        const mockModules = {}
+
+        if (options.mockTsDeclarationLocation) {
+            mockModules["ts-declaration-location"] = {
+                throws: new Error(
+                    "Cannot find module 'ts-declaration-location'"
+                ),
+            }
+        }
+
+        // Stub for the require function.
+        mockRequire = sinon
+            .stub(Module.prototype, "require")
+            .callsFake(function (id) {
+                if (mockModules[id] && mockModules[id].throws) {
+                    throw mockModules[id].throws
+                }
+                return originalRequire.apply(this, arguments)
+            })
+
+        if (options.mockTypeScriptServices) {
+            const mockGetParserServices = function () {
+                return null
+            }
+
+            mockModule(
+                "../../../lib/util/get-parser-services",
+                mockGetParserServices
+            )
+        }
+
+        // Directly create and test the rule.
+        const rule = require("../../../lib/rules/no-sync")
+
+        // Context with required fields to satisfy TypeScript parser requirements.
+        const context = {
+            options: [
+                {
+                    ignores: [
+                        {
+                            from: "file",
+                        },
+                    ],
+                },
+            ],
+        }
+
+        // Node that triggers the rule.
+        const node = {
+            name: "fooSync",
+        }
+
+        // Test if the rule throws the expected error.
+        let errorThrown = false
+        try {
+            const ruleListener = rule.create(context)
+            const selectors = Object.keys(ruleListener)
+
+            for (const selector of selectors) {
+                try {
+                    if (typeof ruleListener[selector] === "function") {
+                        ruleListener[selector](node)
+                    }
+                } catch (e) {
+                    if (e.message.match(options.expectedError)) {
+                        errorThrown = true
+                        break
+                    }
+                }
+            }
+        } catch (e) {
+            if (e.message.match(options.expectedError)) {
+                errorThrown = true
+            } else {
+                throw e
+            }
+        }
+
+        assert.ok(
+            errorThrown,
+            `Expected error matching ${options.expectedError} was not thrown`
+        )
+    }
+
+    beforeEach(() => {
+        delete require.cache[require.resolve("../../../lib/rules/no-sync")]
+        delete require.cache[
+            require.resolve("../../../lib/util/get-parser-services")
+        ]
+    })
+
+    afterEach(() => {
+        if (mockRequire && typeof mockRequire.restore === "function") {
+            mockRequire.restore()
+        }
+
+        sinon.restore()
+        module.require = originalRequire
+    })
+
+    it("should throw if `ts-declaration-location` is not installed", function () {
+        testWithMissingDependency({
+            mockTsDeclarationLocation: true,
+            mockTypeScriptServices: false,
+            expectedError: /ts-declaration-location not available/,
+        })
+    })
+
+    it("should throw if TypeScript parser services are not available", function () {
+        testWithMissingDependency({
+            mockTsDeclarationLocation: false,
+            mockTypeScriptServices: true,
+            expectedError: /TypeScript parser services not available/,
+        })
+    })
+
+    it("should throw if both `ts-declaration-location` and `typescript` are not available", function () {
+        testWithMissingDependency({
+            mockTsDeclarationLocation: true,
+            mockTypeScriptServices: true,
+            expectedError:
+                /TypeScript parser services not available|ts-declaration-location not available/,
+        })
+    })
 })


### PR DESCRIPTION
## Description

- Move `ts-declaration-location` from `dependencies` to `devDependencies` and `peerDependencies`, declaring it as optional on `peerDependenciesMeta`, which has `typescript` as a peer dependency.
  As `ts-declaration-location` is already tentatively loaded for `n/no-sync`, the plugin keeps working as expected, throwing with a message identifying the missing package in case it'd be needed while trying to use the `ignores` option with a non-string value.
- Update the `n/no-sync` documentation to refer the updated peer dependency requirement.
- Update `n/no-sync` rule to conditionally require `ts-declaration-location` only when advanced ignores are used.
- Add `typescript` as an optional peer dependency for the `n/no-sync` rule, used on `lib/util/get-full-type-name.js`, removing unused `eslint-disable` directive `n/no-unpublished-require`.

> [!NOTE]
> ~Set as `feat` as this should be at least a minor bump, as it may break a lint build.~
> Updated to `feat!` after discussion, as it's a breaking change for TypeScript users using advanced TypeScript-based ignores.

## Related issues

- Warning received while installing `eslint-plugin-n` on JS projects without `typescript`:

  ```sh
  warning "eslint-plugin-n > @typescript-eslint/utils@8.34.1" has unmet peer dependency "typescript@>=4.8.4 <5.9.0".
  warning "eslint-plugin-n > ts-declaration-location@1.0.7" has unmet peer dependency "typescript@>=4.0.0".
  warning "eslint-plugin-n > @typescript-eslint/utils > @typescript-eslint/typescript-estree@8.34.1" has unmet peer dependency "typescript@>=4.8.4 <5.9.0".
  warning "eslint-plugin-n > @typescript-eslint/utils > @typescript-eslint/typescript-estree > @typescript-eslint/project-service@8.34.1" has unmet peer dependency "typescript@>=4.8.4 <5.9.0".
  warning "eslint-plugin-n > @typescript-eslint/utils > @typescript-eslint/typescript-estree > @typescript-eslint/tsconfig-utils@8.34.1" has unmet peer dependency "typescript@>=4.8.4 <5.9.0".
  warning "eslint-plugin-n > @typescript-eslint/utils > @typescript-eslint/typescript-estree > ts-api-utils@2.1.0" has unmet peer dependency "typescript@>=4.8.4".
  ```

- #449 addressed `@typescript-eslint/utils`.