### PR TITLE
docs: safely disable no-unpublished-bin npm v10+

### DIFF
--- a/docs/rules/no-unpublished-bin.md
+++ b/docs/rules/no-unpublished-bin.md
@@ -4,6 +4,8 @@
 
 <!-- end auto-generated rule header -->
 
+Users can safely disable this rule if using npm v10 and later.
+
 We can publish CLI commands by `npm`. It uses `bin` field of `package.json`.
 
 ```json


### PR DESCRIPTION
Updates documentation with note that no-unpublished-bin can be safely disabled if using newer versions of npm. 

Rule will be removed from recommended in #485 