### PR TITLE
fix: avoid any type for no-top-level-await listener node (build issue)

### DIFF
--- a/lib/rules/no-top-level-await.js
+++ b/lib/rules/no-top-level-await.js
@@ -120,6 +120,9 @@ module.exports = {
             ":function:exit"() {
                 functionDepth--
             },
+            /**
+             * @param {import('estree').AwaitExpression | import('estree').ForOfStatement | import('estree').VariableDeclaration} node
+             */
             "AwaitExpression, ForOfStatement[await=true], VariableDeclaration[kind='await using']"(
                 node
             ) {


### PR DESCRIPTION
Currently in branch `main`, `npm run prepack` fails because of a type issue - this PR fixes it