### PR TITLE
fix(file-extension-in-import): handle directory index imports

### DIFF
--- a/lib/rules/file-extension-in-import.js
+++ b/lib/rules/file-extension-in-import.js
@@ -7,6 +7,7 @@
 const path = require("path")
 const fs = require("fs")
 const { convertTsExtensionToJs } = require("../util/map-typescript-extension")
+const getTryExtensions = require("../util/get-try-extensions")
 const visitImport = require("../util/visit-import")
 
 /**
@@ -27,6 +28,34 @@ function getExistingExtensions(filePath) {
     } catch {
         return []
     }
+}
+
+/**
+ * Get the extension of an index file in the given directory.
+ * @param {string} directoryPath The directory path to check.
+ * @param {string[]} tryExtensions Ordered extension preferences.
+ * @returns {string | null} The index file extension or null if none.
+ */
+function getIndexExtension(directoryPath, tryExtensions) {
+    try {
+        if (fs.statSync(directoryPath).isDirectory() === false) {
+            return null
+        }
+    } catch {
+        return null
+    }
+
+    const existing = getExistingExtensions(path.join(directoryPath, "index"))
+    if (existing.length === 0) {
+        return null
+    }
+
+    const preferred = tryExtensions.find(ext => existing.includes(ext))
+    if (preferred) {
+        return preferred
+    }
+
+    return existing[0] || null
 }
 
 /**
@@ -69,6 +98,7 @@ module.exports = {
         }
         const defaultStyle = context.options[0] || "always"
         const overrideStyle = context.options[1] || {}
+        const tryExtensions = getTryExtensions(context, 1)
 
         /**
          * @param {import("../util/import-target.js")} target
@@ -88,11 +118,24 @@ module.exports = {
             const actualExt = path.extname(filePath)
             const style = overrideStyle[actualExt] || defaultStyle
 
-            const expectedExt = convertTsExtensionToJs(
+            let expectedExt = convertTsExtensionToJs(
                 context,
                 filePath,
                 actualExt
             )
+            let isDirectoryImport = false
+
+            if (currentExt === "" && actualExt === "") {
+                const indexExt = getIndexExtension(filePath, tryExtensions)
+                if (indexExt) {
+                    isDirectoryImport = true
+                    expectedExt = convertTsExtensionToJs(
+                        context,
+                        path.join(filePath, `index${indexExt}`),
+                        indexExt
+                    )
+                }
+            }
 
             // Verify.
             if (style === "always" && currentExt !== expectedExt) {
@@ -106,6 +149,13 @@ module.exports = {
                         }
 
                         const index = node.range[1] - 1
+                        if (isDirectoryImport) {
+                            const needsSlash = /[/\\]$/.test(name) ? "" : "/"
+                            return fixer.insertTextBeforeRange(
+                                [index, index],
+                                `${needsSlash}index${expectedExt}`
+                            )
+                        }
                         return fixer.insertTextBeforeRange(
                             [index, index],
                             expectedExt

--- a/tests/fixtures/file-extension-in-import/my-folder/index.js
+++ b/tests/fixtures/file-extension-in-import/my-folder/index.js
@@ -1,0 +1,1 @@
+export const util = () => {}

--- a/tests/lib/rules/file-extension-in-import.js
+++ b/tests/lib/rules/file-extension-in-import.js
@@ -224,6 +224,18 @@ new RuleTester({
         },
         {
             filename: fixture("test.js"),
+            code: "import { util } from './my-folder'",
+            output: "import { util } from './my-folder/index.js'",
+            errors: [{ messageId: "requireExt", data: { ext: ".js" } }],
+        },
+        {
+            filename: fixture("test.js"),
+            code: "import { util } from './my-folder/'",
+            output: "import { util } from './my-folder/index.js'",
+            errors: [{ messageId: "requireExt", data: { ext: ".js" } }],
+        },
+        {
+            filename: fixture("test.js"),
             code: "import './b'",
             output: "import './b.json'",
             errors: [{ messageId: "requireExt", data: { ext: ".json" } }],


### PR DESCRIPTION
Fixes #403

## Summary
- lookup `index.*` extensions for directory imports so file-extension-in-import knows what to require
- reuse the rule's try-extensions order and convert the resolved extension before comparing/fixing
- update the fixer to append `index` (plus a slash when needed) and add fixtures/tests covering both `./dir` and `./dir/`

## Testing
- `npm run test:mocha tests/lib/rules/file-extension-in-import.js` runs through

## Notes
- CI is not running through because of issues currently in master also; #498 solves one of the issues
- Created this fix using Codex, did full review myself!
