### PR TITLE
test(no-missing-import): align fixture message with latest resolver output

### DIFF
--- a/tests/lib/rules/no-missing-import.js
+++ b/tests/lib/rules/no-missing-import.js
@@ -397,7 +397,7 @@ ruleTester.run("no-missing-import", rule, {
                     messageId: "notFound",
                     data: {
                         resolveError: [
-                            "Package path ./sub.mjs is not exported from package",
+                            '"./sub.mjs" is not exported under the conditions ["node","require","import"] from package',
                             fixture("node_modules/esm-module"),
                             `(see exports field in ${fixture(
                                 "node_modules/esm-module/package.json"


### PR DESCRIPTION
## Problem

1 test regarding `no-missing-import` is currently failing in branch `main`, see https://github.com/eslint-community/eslint-plugin-n/actions/runs/20685299520/job/59385038476#step:6:55

## Fix

align fixture resolveError message with the current resolver output
