### PR TITLE
feat: add `prefer-global/timers` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ For [Shareable Configs](https://eslint.org/docs/latest/developer-guide/shareable
 | [prefer-global/process](docs/rules/prefer-global/process.md)                                 | enforce either `process` or `require("process")`                            |      |    |    |
 | [prefer-global/text-decoder](docs/rules/prefer-global/text-decoder.md)                       | enforce either `TextDecoder` or `require("util").TextDecoder`               |      |    |    |
 | [prefer-global/text-encoder](docs/rules/prefer-global/text-encoder.md)                       | enforce either `TextEncoder` or `require("util").TextEncoder`               |      |    |    |
+| [prefer-global/timers](docs/rules/prefer-global/timers.md)                                   | enforce either global timer functions or `require("timers")`                |      |    |    |
 | [prefer-global/url](docs/rules/prefer-global/url.md)                                         | enforce either `URL` or `require("url").URL`                                |      |    |    |
 | [prefer-global/url-search-params](docs/rules/prefer-global/url-search-params.md)             | enforce either `URLSearchParams` or `require("url").URLSearchParams`        |      |    |    |
 | [prefer-node-protocol](docs/rules/prefer-node-protocol.md)                                   | enforce using the `node:` protocol when importing Node.js builtin modules.  |      | 🔧 |    |

--- a/docs/rules/prefer-global/timers.md
+++ b/docs/rules/prefer-global/timers.md
@@ -1,0 +1,71 @@
+# Enforce either global timer functions or `require("timers")` (`n/prefer-global/timers`)
+
+<!-- end auto-generated rule header -->
+
+The timer functions `clearImmediate`, `clearInterval`, `clearTimeout`, `setImmediate`, `setInterval`, and `setTimeout` are defined as global variables but are also available in the `timers` module.
+
+```js
+console.log(setTimeout === require("timers").setTimeout) //→ true
+```
+
+It will be readable if we use either consistently.
+
+## 📖 Rule Details
+
+This rule enforces which timer functions we should use.
+
+### Options
+
+This rule has a string option.
+
+```json
+{
+    "n/prefer-global/timers": ["error", "always" | "never"]
+}
+```
+
+- `"always"` (default) ... enforces to use the global timer functions rather than `require("timers").*`.
+- `"never"` ... enforces to use `require("timers").*` rather than the global timer functions.
+
+#### always
+
+Examples of 👎 **incorrect** code for this rule:
+
+```js
+/*eslint n/prefer-global/timers: [error]*/
+
+const { setTimeout } = require("timers")
+setTimeout(() => {}, 1000)
+```
+
+Examples of 👍 **correct** code for this rule:
+
+```js
+/*eslint n/prefer-global/timers: [error]*/
+
+setTimeout(() => {}, 1000)
+```
+
+#### never
+
+Examples of 👎 **incorrect** code for the `"never"` option:
+
+```js
+/*eslint n/prefer-global/timers: [error, never]*/
+
+setTimeout(() => {}, 1000)
+```
+
+Examples of 👍 **correct** code for the `"never"` option:
+
+```js
+/*eslint n/prefer-global/timers: [error, never]*/
+
+const { setTimeout } = require("timers")
+setTimeout(() => {}, 1000)
+```
+
+## 🔎 Implementation
+
+- [Rule source](../../../lib/rules/prefer-global/timers.js)
+- [Test source](../../../tests/lib/rules/prefer-global/timers.js)

--- a/lib/all-rules.js
+++ b/lib/all-rules.js
@@ -43,6 +43,7 @@ module.exports = {
     "prefer-global/text-encoder": require("./rules/prefer-global/text-encoder"),
     "prefer-global/url-search-params": require("./rules/prefer-global/url-search-params"),
     "prefer-global/url": require("./rules/prefer-global/url"),
+    "prefer-global/timers": require("./rules/prefer-global/timers"),
     "prefer-node-protocol": require("./rules/prefer-node-protocol"),
     "prefer-promises/dns": require("./rules/prefer-promises/dns"),
     "prefer-promises/fs": require("./rules/prefer-promises/fs"),

--- a/lib/rules/prefer-global/timers.js
+++ b/lib/rules/prefer-global/timers.js
@@ -1,0 +1,66 @@
+/**
+ * @author Pixel998
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const { READ } = require("@eslint-community/eslint-utils")
+const checkForPreferGlobal = require("../../util/check-prefer-global")
+
+const traceMap = {
+    globals: {
+        clearImmediate: { [READ]: true },
+        clearInterval: { [READ]: true },
+        clearTimeout: { [READ]: true },
+        setImmediate: { [READ]: true },
+        setInterval: { [READ]: true },
+        setTimeout: { [READ]: true },
+    },
+    modules: {
+        timers: {
+            clearImmediate: { [READ]: true },
+            clearInterval: { [READ]: true },
+            clearTimeout: { [READ]: true },
+            setImmediate: { [READ]: true },
+            setInterval: { [READ]: true },
+            setTimeout: { [READ]: true },
+        },
+        "node:timers": {
+            clearImmediate: { [READ]: true },
+            clearInterval: { [READ]: true },
+            clearTimeout: { [READ]: true },
+            setImmediate: { [READ]: true },
+            setInterval: { [READ]: true },
+            setTimeout: { [READ]: true },
+        },
+    },
+}
+
+/** @type {import('../rule-module').RuleModule} */
+module.exports = {
+    meta: {
+        docs: {
+            description:
+                'enforce either global timer functions or `require("timers")`',
+            recommended: false,
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global/timers.md",
+        },
+        type: "suggestion",
+        fixable: null,
+        schema: [{ enum: ["always", "never"] }],
+        messages: {
+            preferGlobal:
+                "Unexpected use of 'require(\"timers\").*'. Use the global variable instead.",
+            preferModule:
+                "Unexpected use of the global variable. Use 'require(\"timers\").*' instead.",
+        },
+    },
+
+    create(context) {
+        return {
+            "Program:exit"() {
+                checkForPreferGlobal(context, traceMap)
+            },
+        }
+    },
+}

--- a/tests/lib/rules/prefer-global/timers.js
+++ b/tests/lib/rules/prefer-global/timers.js
@@ -1,0 +1,237 @@
+/**
+ * @author Pixel998
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const RuleTester = require("#test-helpers").RuleTester
+const rule = require("../../../../lib/rules/prefer-global/timers")
+
+const provideModuleMethods = ["require", "process.getBuiltinModule"]
+
+new RuleTester().run("prefer-global/timers", rule, {
+    valid: [
+        "clearImmediate(id)",
+        "clearInterval(id)",
+        "clearTimeout(id)",
+        "setImmediate(() => {})",
+        "setInterval(() => {}, 1000)",
+        "setTimeout(() => {}, 1000)",
+        {
+            code: "clearImmediate(id)",
+            options: ["always"],
+        },
+        {
+            code: "clearInterval(id)",
+            options: ["always"],
+        },
+        {
+            code: "clearTimeout(id)",
+            options: ["always"],
+        },
+        {
+            code: "setImmediate(() => {})",
+            options: ["always"],
+        },
+        {
+            code: "setInterval(() => {}, 1000)",
+            options: ["always"],
+        },
+        {
+            code: "setTimeout(() => {}, 1000)",
+            options: ["always"],
+        },
+        ...provideModuleMethods.flatMap(method => [
+            {
+                code: `const { clearImmediate } = ${method}('timers'); clearImmediate(id)`,
+                options: ["never"],
+            },
+            {
+                code: `const { clearImmediate } = ${method}('node:timers'); clearImmediate(id)`,
+                options: ["never"],
+            },
+            {
+                code: `const { clearInterval } = ${method}('timers'); clearInterval(id)`,
+                options: ["never"],
+            },
+            {
+                code: `const { clearInterval } = ${method}('node:timers'); clearInterval(id)`,
+                options: ["never"],
+            },
+            {
+                code: `const { clearTimeout } = ${method}('timers'); clearTimeout(id)`,
+                options: ["never"],
+            },
+            {
+                code: `const { clearTimeout } = ${method}('node:timers'); clearTimeout(id)`,
+                options: ["never"],
+            },
+            {
+                code: `const { setImmediate } = ${method}('timers'); setImmediate(() => {})`,
+                options: ["never"],
+            },
+            {
+                code: `const { setImmediate } = ${method}('node:timers'); setImmediate(() => {})`,
+                options: ["never"],
+            },
+            {
+                code: `const { setInterval } = ${method}('timers'); setInterval(() => {}, 1000)`,
+                options: ["never"],
+            },
+            {
+                code: `const { setInterval } = ${method}('node:timers'); setInterval(() => {}, 1000)`,
+                options: ["never"],
+            },
+            {
+                code: `const { setTimeout } = ${method}('timers'); setTimeout(() => {}, 1000)`,
+                options: ["never"],
+            },
+            {
+                code: `const { setTimeout } = ${method}('node:timers'); setTimeout(() => {}, 1000)`,
+                options: ["never"],
+            },
+        ]),
+    ],
+    invalid: [
+        ...provideModuleMethods.flatMap(method => [
+            {
+                code: `const { clearImmediate } = ${method}('timers'); clearImmediate(id)`,
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { clearImmediate } = ${method}('node:timers'); clearImmediate(id)`,
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { clearImmediate } = ${method}('timers'); clearImmediate(id)`,
+                options: ["always"],
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { clearImmediate } = ${method}('node:timers'); clearImmediate(id)`,
+                options: ["always"],
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { clearInterval } = ${method}('timers'); clearInterval(id)`,
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { clearInterval } = ${method}('node:timers'); clearInterval(id)`,
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { clearInterval } = ${method}('timers'); clearInterval(id)`,
+                options: ["always"],
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { clearInterval } = ${method}('node:timers'); clearInterval(id)`,
+                options: ["always"],
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { clearTimeout } = ${method}('timers'); clearTimeout(id)`,
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { clearTimeout } = ${method}('node:timers'); clearTimeout(id)`,
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { clearTimeout } = ${method}('timers'); clearTimeout(id)`,
+                options: ["always"],
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { clearTimeout } = ${method}('node:timers'); clearTimeout(id)`,
+                options: ["always"],
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { setImmediate } = ${method}('timers'); setImmediate(() => {})`,
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { setImmediate } = ${method}('node:timers'); setImmediate(() => {})`,
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { setImmediate } = ${method}('timers'); setImmediate(() => {})`,
+                options: ["always"],
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { setImmediate } = ${method}('node:timers'); setImmediate(() => {})`,
+                options: ["always"],
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { setInterval } = ${method}('timers'); setInterval(() => {}, 1000)`,
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { setInterval } = ${method}('node:timers'); setInterval(() => {}, 1000)`,
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { setInterval } = ${method}('timers'); setInterval(() => {}, 1000)`,
+                options: ["always"],
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { setInterval } = ${method}('node:timers'); setInterval(() => {}, 1000)`,
+                options: ["always"],
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { setTimeout } = ${method}('timers'); setTimeout(() => {}, 1000)`,
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { setTimeout } = ${method}('node:timers'); setTimeout(() => {}, 1000)`,
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { setTimeout } = ${method}('timers'); setTimeout(() => {}, 1000)`,
+                options: ["always"],
+                errors: [{ messageId: "preferGlobal" }],
+            },
+            {
+                code: `const { setTimeout } = ${method}('node:timers'); setTimeout(() => {}, 1000)`,
+                options: ["always"],
+                errors: [{ messageId: "preferGlobal" }],
+            },
+        ]),
+        {
+            code: "clearImmediate(id)",
+            options: ["never"],
+            errors: [{ messageId: "preferModule" }],
+        },
+        {
+            code: "clearInterval(id)",
+            options: ["never"],
+            errors: [{ messageId: "preferModule" }],
+        },
+        {
+            code: "clearTimeout(id)",
+            options: ["never"],
+            errors: [{ messageId: "preferModule" }],
+        },
+        {
+            code: "setImmediate(() => {})",
+            options: ["never"],
+            errors: [{ messageId: "preferModule" }],
+        },
+        {
+            code: "setInterval(() => {}, 1000)",
+            options: ["never"],
+            errors: [{ messageId: "preferModule" }],
+        },
+        {
+            code: "setTimeout(() => {}, 1000)",
+            options: ["never"],
+            errors: [{ messageId: "preferModule" }],
+        },
+    ],
+})


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint Community adheres to the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR introduces the `prefer-global/timers` rule to enforce consistent usage of timer functions—including `setImmediate`, `setInterval`, `setTimeout`, and their `clear*` counterparts—as either global variables or as imports from the `node:timers` module.

#### What changes did you make? (Give an overview)

- Implemented `prefer-global/crypto` rule
- Added Documentation
- Added Tests

#### Related Issues

Closes #339

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
