### PR TITLE
refactor: dedupe `prefer-global/timers` trace map

### DIFF
--- a/lib/rules/prefer-global/timers.js
+++ b/lib/rules/prefer-global/timers.js
@@ -7,32 +7,20 @@
 const { READ } = require("@eslint-community/eslint-utils")
 const checkForPreferGlobal = require("../../util/check-prefer-global")
 
+const timers = {
+    clearImmediate: { [READ]: true },
+    clearInterval: { [READ]: true },
+    clearTimeout: { [READ]: true },
+    setImmediate: { [READ]: true },
+    setInterval: { [READ]: true },
+    setTimeout: { [READ]: true },
+}
+
 const traceMap = {
-    globals: {
-        clearImmediate: { [READ]: true },
-        clearInterval: { [READ]: true },
-        clearTimeout: { [READ]: true },
-        setImmediate: { [READ]: true },
-        setInterval: { [READ]: true },
-        setTimeout: { [READ]: true },
-    },
+    globals: timers,
     modules: {
-        timers: {
-            clearImmediate: { [READ]: true },
-            clearInterval: { [READ]: true },
-            clearTimeout: { [READ]: true },
-            setImmediate: { [READ]: true },
-            setInterval: { [READ]: true },
-            setTimeout: { [READ]: true },
-        },
-        "node:timers": {
-            clearImmediate: { [READ]: true },
-            clearInterval: { [READ]: true },
-            clearTimeout: { [READ]: true },
-            setImmediate: { [READ]: true },
-            setInterval: { [READ]: true },
-            setTimeout: { [READ]: true },
-        },
+        timers,
+        "node:timers": timers,
     },
 }
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint Community adheres to the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Reduce repetition in the `prefer-global/timers` rule by sharing a single trace-map definition.

#### What changes did you make? (Give an overview)

Extract a shared timers trace map and reuse it for `globals`, `modules.timers`, and `modules["node:timers"]`.

#### Related Issues

https://github.com/eslint-community/eslint-plugin-n/pull/515#discussion_r2786441463

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
