### PR TITLE
fix(prefer-promises/fs): add missing fs.promises APIs

### DIFF
--- a/lib/rules/prefer-promises/fs.js
+++ b/lib/rules/prefer-promises/fs.js
@@ -36,6 +36,12 @@ const traceMap = {
         writeFile: { [CALL]: true },
         appendFile: { [CALL]: true },
         readFile: { [CALL]: true },
+        cp: { [CALL]: true },
+        glob: { [CALL]: true },
+        lutimes: { [CALL]: true },
+        opendir: { [CALL]: true },
+        rm: { [CALL]: true },
+        statfs: { [CALL]: true },
     },
 }
 traceMap["node:fs"] = traceMap.fs

--- a/tests/lib/rules/prefer-promises/fs.js
+++ b/tests/lib/rules/prefer-promises/fs.js
@@ -183,5 +183,33 @@ new RuleTester({
                 { messageId: "preferPromises", data: { name: "readFile" } },
             ],
         },
+        {
+            code: "const fs = require('fs'); fs.cp()",
+            errors: [{ messageId: "preferPromises", data: { name: "cp" } }],
+        },
+        {
+            code: "const fs = require('fs'); fs.glob()",
+            errors: [{ messageId: "preferPromises", data: { name: "glob" } }],
+        },
+        {
+            code: "const fs = require('fs'); fs.lutimes()",
+            errors: [
+                { messageId: "preferPromises", data: { name: "lutimes" } },
+            ],
+        },
+        {
+            code: "const fs = require('fs'); fs.opendir()",
+            errors: [
+                { messageId: "preferPromises", data: { name: "opendir" } },
+            ],
+        },
+        {
+            code: "const fs = require('fs'); fs.rm()",
+            errors: [{ messageId: "preferPromises", data: { name: "rm" } }],
+        },
+        {
+            code: "const fs = require('fs'); fs.statfs()",
+            errors: [{ messageId: "preferPromises", data: { name: "statfs" } }],
+        },
     ],
 })


### PR DESCRIPTION
Closes #518

## Problem

The 
/prefer-promises/fs rule was missing several APIs that have been added to s.promises since the rule was originally written. This means the rule silently ignored callback usage of these newer methods:

| Method | Available Since |
|--------|----------------|
| s.cp() | Node.js v16.7.0 |
| s.rm() | Node.js v14.14.0 |
| s.lutimes() | Node.js v14.5.0 |
| s.opendir() | Node.js v12.12.0 |
| s.statfs() | Node.js v19.6.0 / v18.15.0 |
| \s.glob()\ | Node.js v22.0.0 |

## Fix

Add the 6 missing methods to the \	raceMap\ in \lib/rules/prefer-promises/fs.js\ and add corresponding \invalid\ test cases for each.

## Tests

All 55 tests pass (\55 passing\).