### PR TITLE
docs(no-callback-literal): remove invalid callback example using object

### DIFF
--- a/docs/rules/no-callback-literal.md
+++ b/docs/rules/no-callback-literal.md
@@ -14,7 +14,6 @@ Examples of 👎 **incorrect** code for this rule:
 /*eslint n/no-callback-literal: "error" */
 
 cb('this is an error string');
-cb({ a: 1 });
 callback(0);
 ```
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
remove invalid callback example using object in `no-callback-literal` rule, since it doesnt report on objects

See:
<img width="728" height="226" alt="image" src="https://github.com/user-attachments/assets/644b1ae4-fc5f-4677-998b-fa9958766a3a" />
 

#### What changes did you make? (Give an overview)
removed invalid example

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
