### PR TITLE
fix: Add explicit mapping for TypeScript extensions

### DIFF
--- a/lib/util/get-typescript-extension-map.js
+++ b/lib/util/get-typescript-extension-map.js
@@ -18,6 +18,8 @@ const PRESERVE_MAPPING = normalise([
     [".tsx", ".jsx"],
 ])
 
+const EXPLICIT_MAPPING = normalise([])
+
 const tsConfigMapping = {
     react: DEFAULT_MAPPING, // Emit .js files with JSX changed to the equivalent React.createElement calls
     "react-jsx": DEFAULT_MAPPING, // Emit .js files with the JSX changed to _jsx calls
@@ -66,6 +68,10 @@ function normalise(typescriptExtensionMap) {
  * @returns {ExtensionMap | null} The `typescriptExtensionMap` value, or `null`.
  */
 function getMappingFromTSConfig(tsconfig) {
+    if (tsconfig?.compilerOptions?.allowImportingTsExtensions) {
+        return EXPLICIT_MAPPING
+    }
+
     const jsx = tsconfig?.compilerOptions?.jsx
 
     if (jsx != null && {}.hasOwnProperty.call(tsConfigMapping, jsx)) {

--- a/tests/lib/rules/no-missing-import.js
+++ b/tests/lib/rules/no-missing-import.js
@@ -340,10 +340,6 @@ ruleTester.run("no-missing-import", rule, {
 
         {
             filename: fixture("ts-allow-extension/test.ts"),
-            code: "import './file.js';",
-        },
-        {
-            filename: fixture("ts-allow-extension/test.ts"),
             code: "import './file.ts';",
         },
 
@@ -431,6 +427,13 @@ ruleTester.run("no-missing-import", rule, {
             filename: fixture("test.js"),
             code: "import a from './a.json';",
             errors: cantResolve("./a.json"),
+        },
+
+        // allowImportingTsExtensions: .js imports for .ts files fail
+        {
+            filename: fixture("ts-allow-extension/test.ts"),
+            code: "import './file.js';",
+            errors: cantResolve("./file.js", "ts-allow-extension"),
         },
 
         // Should work fine if the filename is relative.


### PR DESCRIPTION
When `allowImportingTsExtensions` is true we want to apply no mapping to typescript file extensions

fixes #422 