### PR TITLE
fix(prefer-promises/fs): add missing fs.promises APIs (cp, glob, lutimes, opendir, rm, statfs)

### DIFF
--- a/lib/rules/prefer-promises/fs.js
+++ b/lib/rules/prefer-promises/fs.js
@@ -36,6 +36,12 @@ const traceMap = {
         writeFile: { [CALL]: true },
         appendFile: { [CALL]: true },
         readFile: { [CALL]: true },
+        cp: { [CALL]: true },
+        glob: { [CALL]: true },
+        lutimes: { [CALL]: true },
+        opendir: { [CALL]: true },
+        rm: { [CALL]: true },
+        statfs: { [CALL]: true },
     },
 }
 traceMap["node:fs"] = traceMap.fs

--- a/tests/lib/rules/prefer-promises/fs.js
+++ b/tests/lib/rules/prefer-promises/fs.js
@@ -183,5 +183,33 @@ new RuleTester({
                 { messageId: "preferPromises", data: { name: "readFile" } },
             ],
         },
+        {
+            code: "const fs = require('fs'); fs.cp()",
+            errors: [{ messageId: "preferPromises", data: { name: "cp" } }],
+        },
+        {
+            code: "const fs = require('fs'); fs.glob()",
+            errors: [{ messageId: "preferPromises", data: { name: "glob" } }],
+        },
+        {
+            code: "const fs = require('fs'); fs.lutimes()",
+            errors: [
+                { messageId: "preferPromises", data: { name: "lutimes" } },
+            ],
+        },
+        {
+            code: "const fs = require('fs'); fs.opendir()",
+            errors: [
+                { messageId: "preferPromises", data: { name: "opendir" } },
+            ],
+        },
+        {
+            code: "const fs = require('fs'); fs.rm()",
+            errors: [{ messageId: "preferPromises", data: { name: "rm" } }],
+        },
+        {
+            code: "const fs = require('fs'); fs.statfs()",
+            errors: [{ messageId: "preferPromises", data: { name: "statfs" } }],
+        },
     ],
 })


### PR DESCRIPTION
## Problem

The `prefer-promises/fs` rule's `traceMap` only covers a subset of `fs` callback-style methods, missing several that have had promise equivalents in Node.js for years:

| Method | `fs.promises` available since |
|---|---|
| `cp` | Node 16.7 |
| `glob` | Node 22 |
| `lutimes` | Node 14.14 |
| `opendir` | Node 12.12 |
| `rm` | Node 14.14 |
| `statfs` | Node 19.6 / 21.2 |

Using any of these callback-style while writing otherwise promise-based code goes silently undetected by the rule, defeating its purpose.

## Fix

Add the six missing methods to `traceMap.fs` (and, by extension, `traceMap["node:fs"]` which is aliased from it):

```js
cp:      { [CALL]: true },
glob:    { [CALL]: true },
lutimes: { [CALL]: true },
opendir: { [CALL]: true },
rm:      { [CALL]: true },
statfs:  { [CALL]: true },
```

## Tests

Added an invalid-code test case for each of the six new methods, verifying that the rule reports `preferPromises` for `fs.cp()`, `fs.glob()`, `fs.lutimes()`, `fs.opendir()`, `fs.rm()`, and `fs.statfs()`.
