### PR TITLE
feat: support `devEngines.runtime` from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ The rules get the supported Node.js version range from the following, falling ba
 1. Rule configuration `version`
 2. ESLint [shared setting](http://eslint.org/docs/user-guide/configuring.html#adding-shared-settings) `node.version`
 3. `package.json` [`engines`] field
-4. `>=16.0.0`
+4. `package.json` [`devEngines.runtime`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines) field (when `name` is `"node"`)
+5. `>=16.0.0`
 
 If you omit the [engines] field, this rule chooses `>=16.0.0` as the configured Node.js version since `16` is the maintained lts (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The rules get the supported Node.js version range from the following, falling ba
 4. `package.json` [`devEngines.runtime`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines) field (when `name` is `"node"`)
 5. `>=16.0.0`
 
-If you omit the [engines] field, this rule chooses `>=16.0.0` as the configured Node.js version since `16` is the maintained lts (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
+If you omit both the [engines] field and the `devEngines.runtime` field (with `name` set to `"node"`), this rule chooses `>=16.0.0` as the configured Node.js version since `16` is the maintained lts (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
 
 For Node.js packages, using the [`engines`] field is recommended because it's the official way to indicate support:
 

--- a/lib/util/get-configured-node-version.js
+++ b/lib/util/get-configured-node-version.js
@@ -28,6 +28,9 @@ function getVersionRange(option) {
  * @typedef {{ [EngineName in 'npm' | 'node' | string]?: string }} Engines
  */
 /**
+ * @typedef {{ name?: string, version?: string, onFail?: string }} DevEngineEntry
+ */
+/**
  * Get the `engines.node` field of package.json.
  * @param {import('eslint').Rule.RuleContext} context The path to the current linting file.
  * @returns {import("semver").Range | undefined} The range object of the `engines.node` field.
@@ -46,11 +49,47 @@ function getEnginesNode(context) {
 }
 
 /**
+ * Get the `devEngines.runtime` (`name: "node"`) version from package.json.
+ * `devEngines.runtime` may be a single object or an array of objects.
+ * See https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines
+ * @param {import('eslint').Rule.RuleContext} context The path to the current linting file.
+ * @returns {import("semver").Range | undefined} The range object of the matching `devEngines.runtime.version`.
+ */
+function getDevEnginesNode(context) {
+    const filename = context.filename
+    const info = getPackageJson(filename)
+    if (
+        info?.devEngines == null ||
+        typeof info.devEngines !== "object" ||
+        Array.isArray(info.devEngines) ||
+        !("runtime" in info.devEngines) ||
+        info.devEngines.runtime == null
+    ) {
+        return
+    }
+    const runtime = info.devEngines.runtime
+    const entries = /** @type {DevEngineEntry[]} */ (
+        Array.isArray(runtime) ? runtime : [runtime]
+    )
+    for (const entry of entries) {
+        if (
+            entry != null &&
+            typeof entry === "object" &&
+            entry.name === "node" &&
+            typeof entry.version === "string"
+        ) {
+            return getSemverRange(entry.version)
+        }
+    }
+}
+
+/**
  * Gets version configuration.
  *
  * 1. Parse a given version then return it if it's valid.
  * 2. Look package.json up and parse `engines.node` then return it if it's valid.
- * 3. Return `>=16.0.0`.
+ * 3. Look package.json up and parse `devEngines.runtime` (`name: "node"`) then return it if it's valid.
+ * 4. Return `>=16.0.0`.
  *
  * @param {import('eslint').Rule.RuleContext} context The version range text.
  * This will be used to look package.json up if `version` is not a valid version range.
@@ -64,6 +103,7 @@ export function getConfiguredNodeVersion(context) {
             /** @type {VersionOption} */ (context.settings?.node)
         ) ??
         getEnginesNode(context) ??
+        getDevEnginesNode(context) ??
         fallbackRange
     )
 }

--- a/tests/fixtures/no-unsupported-features--ecma/dev-engines-array-gte-7.5.0/package.json
+++ b/tests/fixtures/no-unsupported-features--ecma/dev-engines-array-gte-7.5.0/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "test",
+    "devEngines": {
+        "runtime": [
+            {
+                "name": "deno",
+                "version": ">=1.0.0"
+            },
+            {
+                "name": "node",
+                "version": ">=7.5.0"
+            }
+        ]
+    }
+}

--- a/tests/fixtures/no-unsupported-features--ecma/dev-engines-gte-7.5.0/package.json
+++ b/tests/fixtures/no-unsupported-features--ecma/dev-engines-gte-7.5.0/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "test",
+    "devEngines": {
+        "runtime": {
+            "name": "node",
+            "version": ">=7.5.0"
+        }
+    }
+}

--- a/tests/fixtures/no-unsupported-features--ecma/dev-engines-non-node-only/package.json
+++ b/tests/fixtures/no-unsupported-features--ecma/dev-engines-non-node-only/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "test",
+    "devEngines": {
+        "runtime": {
+            "name": "deno",
+            "version": ">=1.0.0"
+        }
+    }
+}

--- a/tests/fixtures/no-unsupported-features--ecma/dev-engines-non-node/package.json
+++ b/tests/fixtures/no-unsupported-features--ecma/dev-engines-non-node/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "test",
+    "engines": {
+        "node": ">=7.5.0"
+    },
+    "devEngines": {
+        "runtime": {
+            "name": "deno",
+            "version": ">=1.0.0"
+        }
+    }
+}

--- a/tests/fixtures/no-unsupported-features--ecma/engines-over-dev-engines/package.json
+++ b/tests/fixtures/no-unsupported-features--ecma/engines-over-dev-engines/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "test",
+    "engines": {
+        "node": ">=4.0.0"
+    },
+    "devEngines": {
+        "runtime": {
+            "name": "node",
+            "version": ">=7.5.0"
+        }
+    }
+}

--- a/tests/lib/rules/no-unsupported-features/es-syntax.js
+++ b/tests/lib/rules/no-unsupported-features/es-syntax.js
@@ -3166,6 +3166,10 @@ runTests([
                 filename: fixture("without-node/a.js"),
                 code: "var a = () => 1",
             },
+            {
+                filename: fixture("dev-engines-non-node-only/a.js"),
+                code: "var a = async () => 1",
+            },
         ],
         invalid: [
             {

--- a/tests/lib/rules/no-unsupported-features/es-syntax.js
+++ b/tests/lib/rules/no-unsupported-features/es-syntax.js
@@ -3255,6 +3255,62 @@ runTests([
                 ],
             },
             {
+                filename: fixture("dev-engines-gte-7.5.0/a.js"),
+                code: "var a = async () => 1",
+                errors: [
+                    {
+                        messageId: "not-supported-till",
+                        data: {
+                            featureName: "async-functions",
+                            supported: ">=7.6.0",
+                            version: ">=7.5.0",
+                        },
+                    },
+                ],
+            },
+            {
+                filename: fixture("dev-engines-array-gte-7.5.0/a.js"),
+                code: "var a = async () => 1",
+                errors: [
+                    {
+                        messageId: "not-supported-till",
+                        data: {
+                            featureName: "async-functions",
+                            supported: ">=7.6.0",
+                            version: ">=7.5.0",
+                        },
+                    },
+                ],
+            },
+            {
+                filename: fixture("engines-over-dev-engines/a.js"),
+                code: "var a = async () => 1",
+                errors: [
+                    {
+                        messageId: "not-supported-till",
+                        data: {
+                            featureName: "async-functions",
+                            supported: ">=7.6.0",
+                            version: ">=4.0.0",
+                        },
+                    },
+                ],
+            },
+            {
+                filename: fixture("dev-engines-non-node/a.js"),
+                code: "var a = async () => 1",
+                errors: [
+                    {
+                        messageId: "not-supported-till",
+                        data: {
+                            featureName: "async-functions",
+                            supported: ">=7.6.0",
+                            version: ">=7.5.0",
+                        },
+                    },
+                ],
+            },
+            {
                 code: "var a = async () => 1",
                 options: [{ version: "7.1.0" }],
                 errors: [


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adds support for reading the Node.js version range from the `devEngines.runtime` field of `package.json`, in addition to the existing `engines.node`. `devEngines` is the [package.json field introduced by npm](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines) for aligning the development environment among contributors.

#### What changes did you make? (Give an overview)

- `lib/util/get-configured-node-version.js`
  - Add `getDevEnginesNode(context)` that extracts the `version` of the `devEngines.runtime` entry whose `name === "node"`.
  - Both the single-object form and the array-of-objects form of `devEngines.runtime` are accepted.
  - Insert it into the resolution chain **after** `engines.node`, so existing behavior is preserved when both fields exist.

  New priority:

  1. Rule option `version`
  2. `settings.n.version` / `settings.node.version`
  3. `package.json` `engines.node`
  4. `package.json` `devEngines.runtime` (when `name` is `"node"`)
  5. `>=16.0.0` (fallback)

- `tests/fixtures/no-unsupported-features--ecma/` — five new fixtures covering:
  - `devEngines.runtime` as a single object
  - `devEngines.runtime` as an array (with non-`node` siblings)
  - both `engines.node` and `devEngines.runtime` present (`engines` wins)
  - `engines.node` present with `devEngines.runtime` for non-`node` (falls through to `engines.node`)
  - `devEngines.runtime` for non-`node` only, no `engines.node` (falls through to the default `>=16.0.0`)

- `tests/lib/rules/no-unsupported-features/es-syntax.js` — corresponding test cases.

- `README.md` — document `devEngines.runtime` in the Configured Node.js version range section.

#### Related Issues

- fixes #418

#### Is there anything you'd like reviewers to focus on?

The chosen priority places `engines.node` above `devEngines.runtime` to keep existing behavior unchanged for published libraries (where `engines.node` is the source of truth for consumers). `devEngines.runtime` is consulted only when `engines.node` is missing, which still benefits dev-only projects that only declare `devEngines`. Happy to swap the priority if you prefer.

![by](https://img.shields.io/badge/-by-grey?style=flat-square)![Claude Code](https://img.shields.io/badge/Claude_Code-D97757?logo=claude&logoColor=fff&style=flat-square)

(English isn't my first language, so this code, commit message, and PR description were produced by an AI agent acting on my instructions and decisions.)