### PR TITLE
fix(prefer-promises/fs): add missing fs.promises APIs (cp, glob, lutimes, opendir, rm, statfs)

### DIFF
--- a/lib/rules/prefer-promises/fs.js
+++ b/lib/rules/prefer-promises/fs.js
@@ -36,6 +36,12 @@ const traceMap = {
         writeFile: { [CALL]: true },
         appendFile: { [CALL]: true },
         readFile: { [CALL]: true },
+        cp: { [CALL]: true },
+        glob: { [CALL]: true },
+        lutimes: { [CALL]: true },
+        opendir: { [CALL]: true },
+        rm: { [CALL]: true },
+        statfs: { [CALL]: true },
     },
 }
 traceMap["node:fs"] = traceMap.fs

--- a/tests/lib/rules/prefer-promises/fs.js
+++ b/tests/lib/rules/prefer-promises/fs.js
@@ -183,5 +183,33 @@ new RuleTester({
                 { messageId: "preferPromises", data: { name: "readFile" } },
             ],
         },
+        {
+            code: "const fs = require('fs'); fs.cp()",
+            errors: [{ messageId: "preferPromises", data: { name: "cp" } }],
+        },
+        {
+            code: "const fs = require('fs'); fs.glob()",
+            errors: [{ messageId: "preferPromises", data: { name: "glob" } }],
+        },
+        {
+            code: "const fs = require('fs'); fs.lutimes()",
+            errors: [
+                { messageId: "preferPromises", data: { name: "lutimes" } },
+            ],
+        },
+        {
+            code: "const fs = require('fs'); fs.opendir()",
+            errors: [
+                { messageId: "preferPromises", data: { name: "opendir" } },
+            ],
+        },
+        {
+            code: "const fs = require('fs'); fs.rm()",
+            errors: [{ messageId: "preferPromises", data: { name: "rm" } }],
+        },
+        {
+            code: "const fs = require('fs'); fs.statfs()",
+            errors: [{ messageId: "preferPromises", data: { name: "statfs" } }],
+        },
     ],
 })


### PR DESCRIPTION
## Problem

The \prefer-promises/fs\ rule only flags a subset of \s\ callback-style APIs. Several APIs that have promise-based equivalents in \s.promises\ are missing from the rule's trace map and are therefore silently allowed:

| Missing API | Added in Node.js |
|---|---|
| \s.cp()\ | v16.7.0 |
| \s.glob()\ | v22.0.0 |
| \s.lutimes()\ | v14.5.0 |
| \s.opendir()\ | v12.12.0 |
| \s.rm()\ | v14.14.0 |
| \s.statfs()\ | v19.6.0 |

## Fix

Add the six missing methods to the \	raceMap\ in \lib/rules/prefer-promises/fs.js\.

## Tests

Added an invalid-case test for each new method in \	ests/lib/rules/prefer-promises/fs.js\.