### PR TITLE
Fix no-extraneous-import for type-only @types dependencies

### DIFF
--- a/lib/util/check-extraneous.js
+++ b/lib/util/check-extraneous.js
@@ -7,6 +7,20 @@ import { getAllowModules } from "./get-allow-modules.js"
 import { getPackageJson } from "./get-package-json.js"
 
 /**
+ * Get the matching DefinitelyTyped package name for a module.
+ * @param {string} moduleName - An npm module name.
+ * @returns {string}
+ */
+function getTypesPackageName(moduleName) {
+    if (moduleName.startsWith("@")) {
+        const [scope, name] = moduleName.slice(1).split("/")
+        return `@types/${scope}__${name}`
+    }
+
+    return `@types/${moduleName}`
+}
+
+/**
  * Checks whether or not each requirement target is published via package.json.
  *
  * It reads package.json and checks the target exists in `dependencies`.
@@ -37,6 +51,10 @@ export function checkExtraneous(context, filePath, targets) {
             target.moduleName != null &&
             target.filePath != null &&
             !dependencies.has(target.moduleName) &&
+            !(
+                target.moduleStyle === "type" &&
+                dependencies.has(getTypesPackageName(target.moduleName))
+            ) &&
             !allowed.has(target.moduleName) &&
             // https://github.com/eslint-community/eslint-plugin-n/issues/379
             !target.hasTSAlias()

--- a/lib/util/import-target.js
+++ b/lib/util/import-target.js
@@ -232,6 +232,15 @@ export class ImportTarget {
                     : "import"
             }
 
+            if (
+                (node.parent.type === "ExportAllDeclaration" ||
+                    node.parent.type === "ExportNamedDeclaration") &&
+                "exportKind" in node.parent &&
+                node.parent.exportKind === "type"
+            ) {
+                return "type"
+            }
+
             node = node.parent
         } while (node.parent)
 

--- a/tests/fixtures/no-extraneous/typesOnly/node_modules/@types/picomatch/index.d.ts
+++ b/tests/fixtures/no-extraneous/typesOnly/node_modules/@types/picomatch/index.d.ts
@@ -1,0 +1,2 @@
+export type Glob = string
+export function scan(): unknown

--- a/tests/fixtures/no-extraneous/typesOnly/node_modules/picomatch/index.js
+++ b/tests/fixtures/no-extraneous/typesOnly/node_modules/picomatch/index.js
@@ -1,0 +1,1 @@
+export function scan() {}

--- a/tests/fixtures/no-extraneous/typesOnly/node_modules/picomatch/package.json
+++ b/tests/fixtures/no-extraneous/typesOnly/node_modules/picomatch/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "picomatch",
+    "version": "0.0.0",
+    "main": "index.js"
+}

--- a/tests/fixtures/no-extraneous/typesOnly/package.json
+++ b/tests/fixtures/no-extraneous/typesOnly/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "test",
+    "version": "0.0.0",
+    "dependencies": {
+        "@types/picomatch": "0.0.0"
+    }
+}

--- a/tests/lib/rules/no-extraneous-import.js
+++ b/tests/lib/rules/no-extraneous-import.js
@@ -4,6 +4,7 @@
  */
 
 import path from "node:path"
+import typescriptParser from "@typescript-eslint/parser"
 import { Linter } from "eslint"
 import { RuleTester } from "#test-helpers"
 import rule from "../../../lib/rules/no-extraneous-import.js"
@@ -145,5 +146,36 @@ ruleTester.run("no-extraneous-import", rule, {
                   },
               ]
             : []),
+    ],
+})
+
+const tsRuleTester = new RuleTester({
+    languageOptions: {
+        parser: typescriptParser,
+        sourceType: "module",
+    },
+})
+tsRuleTester.run("no-extraneous-import/typescript", rule, {
+    valid: [
+        {
+            filename: fixture("typesOnly/a.ts"),
+            code: "import type { Glob } from 'picomatch'",
+        },
+        {
+            filename: fixture("typesOnly/a.ts"),
+            code: "export type { Glob } from 'picomatch'",
+        },
+    ],
+    invalid: [
+        {
+            filename: fixture("typesOnly/a.ts"),
+            code: "import { scan } from 'picomatch'",
+            errors: ['"picomatch" is extraneous.'],
+        },
+        {
+            filename: fixture("typesOnly/a.ts"),
+            code: "export { scan } from 'picomatch'",
+            errors: ['"picomatch" is extraneous.'],
+        },
     ],
 })


### PR DESCRIPTION
## Summary

Fixes `no-extraneous-import` for type-only imports backed by `@types/*` dependencies.

## What changed

- Added regression coverage for `import type` and `export type` from a package with only its `@types/*` package declared.
- Allowed type-only import/export targets when the matching DefinitelyTyped package is declared.
- Preserved extraneous reports for runtime imports and exports.

## Why

Issue #486 reports that TypeScript type-only imports from packages such as `picomatch` are reported as extraneous even when `@types/picomatch` is installed directly.

## Testing

- `npm run test:mocha -- tests/lib/rules/no-extraneous-import.js`
- `npm run lint`
- `npm run test:types`
- `npm test`
- `git diff --check`

Fixes #486