### PR TITLE
fix: Allow leading forwardslash in package.json "files" field (#534)

### DIFF
--- a/lib/util/get-npmignore.js
+++ b/lib/util/get-npmignore.js
@@ -102,7 +102,7 @@ function parseWhiteList(files) {
     for (const file of files) {
         if (typeof file === "string" && file) {
             const body = path.posix
-                .normalize(file.replace(/^!/u, ""))
+                .normalize(file.replace(/^[!/]/u, ""))
                 .replace(/\/+$/u, "")
 
             if (file.startsWith("!")) {

--- a/tests/fixtures/no-top-level-await/dot-slash-files/package.json
+++ b/tests/fixtures/no-top-level-await/dot-slash-files/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "test",
+    "version": "1.0.0",
+    "files": [
+        "./lib"
+    ]
+}

--- a/tests/fixtures/no-top-level-await/slash-files/package.json
+++ b/tests/fixtures/no-top-level-await/slash-files/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "test",
+    "version": "1.0.0",
+    "files": [
+        "/lib"
+    ]
+}

--- a/tests/lib/rules/no-top-level-await.js
+++ b/tests/lib/rules/no-top-level-await.js
@@ -60,6 +60,22 @@ new RuleTester({
             code: "for await (const e of asyncIterate()) { /* ... */ }",
         },
         {
+            filename: fixture("dot-slash-files/src/a.js"),
+            code: "const foo = await import('foo')",
+        },
+        {
+            filename: fixture("dot-slash-files/src/a.js"),
+            code: "for await (const e of asyncIterate()) { /* ... */ }",
+        },
+        {
+            filename: fixture("slash-files/src/a.js"),
+            code: "const foo = await import('foo')",
+        },
+        {
+            filename: fixture("slash-files/src/a.js"),
+            code: "for await (const e of asyncIterate()) { /* ... */ }",
+        },
+        {
             filename: fixture("simple-npmignore/src/a.js"),
             code: "const foo = await import('foo')",
         },
@@ -142,6 +158,54 @@ new RuleTester({
         },
         {
             filename: fixture("simple-files/lib/a.js"),
+            code: "for await (const e of asyncIterate()) { /* ... */ }",
+            errors: [
+                {
+                    message:
+                        "Top-level `await` is forbidden in published modules.",
+                    line: 1,
+                    column: 1,
+                },
+            ],
+        },
+        {
+            filename: fixture("dot-slash-files/lib/a.js"),
+            code: "const foo = await import('foo')",
+            errors: [
+                {
+                    message:
+                        "Top-level `await` is forbidden in published modules.",
+                    line: 1,
+                    column: 13,
+                },
+            ],
+        },
+        {
+            filename: fixture("dot-slash-files/lib/a.js"),
+            code: "for await (const e of asyncIterate()) { /* ... */ }",
+            errors: [
+                {
+                    message:
+                        "Top-level `await` is forbidden in published modules.",
+                    line: 1,
+                    column: 1,
+                },
+            ],
+        },
+        {
+            filename: fixture("slash-files/lib/a.js"),
+            code: "const foo = await import('foo')",
+            errors: [
+                {
+                    message:
+                        "Top-level `await` is forbidden in published modules.",
+                    line: 1,
+                    column: 13,
+                },
+            ],
+        },
+        {
+            filename: fixture("slash-files/lib/a.js"),
             code: "for await (const e of asyncIterate()) { /* ... */ }",
             errors: [
                 {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint Community adheres to the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Entries in the package.json "files" field that start with a forwardslash are now used by rules "n/hashbang", "n/no-top-level-await" and "n/no-unpublished-*" when determining which files are published. These entries were previously ignored by eslint-plugin-n, which prevented valid warnings from being reported.

#### What changes did you make? (Give an overview)

- Background: There is code in the get-npmignore.js parseWhiteList function which adds a forwardslash to the beginning of each entry in the "files" field. This makes the pattern only apply relative to the directory containing package.json, matching the behavior of npm. Without this forwardslash, a gitignore pattern without any separators (or with only separators at the end) would match files in any subdirectory.

- Previous behavior: For "files" entries that already started with a forwardslash, a second forwardslash would be added. The resulting pattern would not match any files.

- New behavior: Remove any existing leading forwardslash so that we don't end up with two of them. Entries starting with a forwardslash will now match files relative to the package.json directory, as npm does.

#### Related Issues

Fixes #534

#### Is there anything you'd like reviewers to focus on?

Several different rules make use of this code but I've only updated the no-top-level-await test. Not sure its worthwhile updating all of them because we already have coverage of the changes. But let me know what you prefer?