### PR TITLE
Allow workspace root dependencies for no-extraneous-import

### DIFF
--- a/lib/util/check-extraneous.js
+++ b/lib/util/check-extraneous.js
@@ -3,8 +3,205 @@
  * See LICENSE file in root directory for full license.
  */
 
+import path from "node:path"
+import globrex from "globrex"
+import { Cache } from "./cache.js"
 import { getAllowModules } from "./get-allow-modules.js"
 import { getPackageJson } from "./get-package-json.js"
+
+const workspacePackageJsonsCache = new Cache()
+const workspacePatternMatcherCache = new Cache()
+
+/**
+ * @param {unknown} workspaces - The package.json workspaces value.
+ * @returns {string[]} Workspace package patterns.
+ */
+function getWorkspacePatterns(workspaces) {
+    if (Array.isArray(workspaces)) {
+        return workspaces.map(String)
+    }
+
+    if (
+        workspaces != null &&
+        typeof workspaces === "object" &&
+        "packages" in workspaces &&
+        Array.isArray(workspaces.packages)
+    ) {
+        return workspaces.packages.map(String)
+    }
+
+    return []
+}
+
+/**
+ * @param {string} pattern - A package.json workspace pattern.
+ * @returns {string} A pattern comparable to path.posix-style relative paths.
+ */
+function normalizeWorkspacePattern(pattern) {
+    return pattern
+        .replace(/\\/gu, "/")
+        .replace(/^\.\//u, "")
+        .replace(/\/+$/u, "")
+}
+
+/**
+ * @param {string} relativePath - A relative package directory path.
+ * @param {string[]} patterns - Workspace package patterns.
+ * @returns {boolean} Whether the path is included by the patterns.
+ */
+function matchesWorkspacePattern(relativePath, patterns) {
+    let matched = false
+
+    for (const rawPattern of patterns) {
+        const negated = rawPattern.startsWith("!")
+        const pattern = normalizeWorkspacePattern(
+            negated ? rawPattern.slice(1) : rawPattern
+        )
+
+        if (pattern === "") {
+            continue
+        }
+
+        if (getWorkspacePatternMatcher(pattern).test(relativePath)) {
+            if (negated) {
+                return false
+            }
+
+            matched = true
+        }
+    }
+
+    return matched
+}
+
+/**
+ * @param {string} pattern - A normalized package.json workspace pattern.
+ * @returns {RegExp} A matcher for package paths.
+ */
+function getWorkspacePatternMatcher(pattern) {
+    let matcher = workspacePatternMatcherCache.get(pattern)
+
+    if (matcher == null) {
+        matcher = globrex(pattern, {
+            extended: true,
+            globstar: true,
+        }).regex
+        workspacePatternMatcherCache.set(pattern, matcher)
+    }
+
+    return matcher
+}
+
+/**
+ * @param {string} dir - A directory path.
+ * @returns {import('type-fest').JsonObject|null} The package.json in the directory, if present.
+ */
+function getPackageJsonInDirectory(dir) {
+    const packageInfo = getPackageJson(path.join(dir, "__placeholder__.js"))
+    const filePath = path.join(dir, "package.json")
+
+    return packageInfo != null && packageInfo.filePath === filePath
+        ? packageInfo
+        : null
+}
+
+/**
+ * @param {import('type-fest').JsonObject} packageInfo - A package.json object.
+ * @param {import('type-fest').JsonObject} workspacePackageInfo - An ancestor package.json object.
+ * @returns {boolean} Whether the package is in the ancestor's workspace.
+ */
+function isWorkspacePackage(packageInfo, workspacePackageInfo) {
+    if (
+        typeof packageInfo.filePath !== "string" ||
+        typeof workspacePackageInfo.filePath !== "string"
+    ) {
+        return false
+    }
+
+    const packageDir = path.dirname(packageInfo.filePath)
+    const workspaceDir = path.dirname(workspacePackageInfo.filePath)
+    const relativePath = path
+        .relative(workspaceDir, packageDir)
+        .replace(/\\/gu, "/")
+
+    if (
+        relativePath === "" ||
+        relativePath === ".." ||
+        relativePath.startsWith("../") ||
+        path.isAbsolute(relativePath)
+    ) {
+        return false
+    }
+
+    return matchesWorkspacePattern(
+        relativePath,
+        getWorkspacePatterns(workspacePackageInfo.workspaces)
+    )
+}
+
+/**
+ * @param {import('type-fest').JsonObject} packageInfo - A package.json object.
+ * @returns {import('type-fest').JsonObject[]} Matching workspace root package.json objects.
+ */
+function getWorkspacePackageJsons(packageInfo) {
+    if (typeof packageInfo.filePath !== "string") {
+        return []
+    }
+
+    const cached = workspacePackageJsonsCache.get(packageInfo.filePath)
+    if (cached != null) {
+        return cached
+    }
+
+    const workspacePackageJsons = []
+    let dir = path.resolve(path.dirname(packageInfo.filePath), "..")
+    let prevDir = ""
+
+    do {
+        const workspacePackageInfo = getPackageJsonInDirectory(dir)
+
+        if (
+            workspacePackageInfo != null &&
+            isWorkspacePackage(packageInfo, workspacePackageInfo)
+        ) {
+            workspacePackageJsons.push(workspacePackageInfo)
+            break
+        }
+
+        prevDir = dir
+        dir = path.resolve(dir, "..")
+    } while (dir !== prevDir)
+
+    workspacePackageJsonsCache.set(packageInfo.filePath, workspacePackageJsons)
+    return workspacePackageJsons
+}
+
+/**
+ * @param {import('type-fest').JsonObject} packageInfo - A package.json object.
+ * @returns {string[]} Package and dependency names.
+ */
+function getPackageNames(packageInfo) {
+    return (
+        typeof packageInfo.name === "string" ? [packageInfo.name] : []
+    ).concat(
+        getDependencyNames(packageInfo.dependencies),
+        getDependencyNames(packageInfo.devDependencies),
+        getDependencyNames(packageInfo.peerDependencies),
+        getDependencyNames(packageInfo.optionalDependencies)
+    )
+}
+
+/**
+ * @param {unknown} dependencies - A package.json dependency object.
+ * @returns {string[]} Dependency names.
+ */
+function getDependencyNames(dependencies) {
+    return dependencies != null &&
+        typeof dependencies === "object" &&
+        Array.isArray(dependencies) === false
+        ? Object.keys(dependencies)
+        : []
+}
 
 /**
  * Checks whether or not each requirement target is published via package.json.
@@ -24,11 +221,8 @@ export function checkExtraneous(context, filePath, targets) {
 
     const allowed = new Set(getAllowModules(context))
     const dependencies = new Set(
-        [packageInfo.name].concat(
-            Object.keys(packageInfo.dependencies || {}),
-            Object.keys(packageInfo.devDependencies || {}),
-            Object.keys(packageInfo.peerDependencies || {}),
-            Object.keys(packageInfo.optionalDependencies || {})
+        getPackageNames(packageInfo).concat(
+            getWorkspacePackageJsons(packageInfo).flatMap(getPackageNames)
         )
     )
 

--- a/lib/util/get-package-json.js
+++ b/lib/util/get-package-json.js
@@ -12,8 +12,6 @@ const cache = new Cache()
 /**
  * Reads the `package.json` data in a given path.
  *
- * Don't cache the data.
- *
  * @param {string} dir - The path to a directory to read.
  * @returns {import('type-fest').JsonObject|null} The read `package.json` data, or null.
  */

--- a/tests/fixtures/no-extraneous/workspace-negated/node_modules/root-dep/index.js
+++ b/tests/fixtures/no-extraneous/workspace-negated/node_modules/root-dep/index.js
@@ -1,0 +1,1 @@
+export default {}

--- a/tests/fixtures/no-extraneous/workspace-negated/node_modules/root-dep/package.json
+++ b/tests/fixtures/no-extraneous/workspace-negated/node_modules/root-dep/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "root-dep",
+    "version": "0.0.0"
+}

--- a/tests/fixtures/no-extraneous/workspace-negated/package.json
+++ b/tests/fixtures/no-extraneous/workspace-negated/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "workspace-negated-root",
+    "version": "0.0.0",
+    "private": true,
+    "workspaces": [
+        "packages/*",
+        "!packages/excluded"
+    ],
+    "dependencies": {
+        "root-dep": "0.0.0"
+    }
+}

--- a/tests/fixtures/no-extraneous/workspace-negated/packages/excluded/package.json
+++ b/tests/fixtures/no-extraneous/workspace-negated/packages/excluded/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "workspace-excluded-app",
+    "version": "0.0.0"
+}

--- a/tests/fixtures/no-extraneous/workspace-negated/packages/excluded/src/index.js
+++ b/tests/fixtures/no-extraneous/workspace-negated/packages/excluded/src/index.js
@@ -1,0 +1,3 @@
+import rootDep from "root-dep"
+
+rootDep()

--- a/tests/fixtures/no-extraneous/workspace-nested/inner/node_modules/root-dep/index.js
+++ b/tests/fixtures/no-extraneous/workspace-nested/inner/node_modules/root-dep/index.js
@@ -1,0 +1,1 @@
+export default {}

--- a/tests/fixtures/no-extraneous/workspace-nested/inner/node_modules/root-dep/package.json
+++ b/tests/fixtures/no-extraneous/workspace-nested/inner/node_modules/root-dep/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "root-dep",
+    "version": "0.0.0"
+}

--- a/tests/fixtures/no-extraneous/workspace-nested/inner/package.json
+++ b/tests/fixtures/no-extraneous/workspace-nested/inner/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "workspace-inner-root",
+    "version": "0.0.0",
+    "private": true,
+    "workspaces": [
+        "packages/*"
+    ],
+    "dependencies": {
+        "root-dep": "0.0.0"
+    }
+}

--- a/tests/fixtures/no-extraneous/workspace-nested/inner/packages/app/package.json
+++ b/tests/fixtures/no-extraneous/workspace-nested/inner/packages/app/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "workspace-nested-app",
+    "version": "0.0.0"
+}

--- a/tests/fixtures/no-extraneous/workspace-nested/inner/packages/app/src/index.js
+++ b/tests/fixtures/no-extraneous/workspace-nested/inner/packages/app/src/index.js
@@ -1,0 +1,3 @@
+import rootDep from "root-dep"
+
+rootDep()

--- a/tests/fixtures/no-extraneous/workspace-nested/node_modules/outer-dep/index.js
+++ b/tests/fixtures/no-extraneous/workspace-nested/node_modules/outer-dep/index.js
@@ -1,0 +1,1 @@
+export default {}

--- a/tests/fixtures/no-extraneous/workspace-nested/node_modules/outer-dep/package.json
+++ b/tests/fixtures/no-extraneous/workspace-nested/node_modules/outer-dep/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "outer-dep",
+    "version": "0.0.0"
+}

--- a/tests/fixtures/no-extraneous/workspace-nested/package.json
+++ b/tests/fixtures/no-extraneous/workspace-nested/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "workspace-outer-root",
+    "version": "0.0.0",
+    "private": true,
+    "workspaces": [
+        "**"
+    ],
+    "dependencies": {
+        "outer-dep": "0.0.0"
+    }
+}

--- a/tests/fixtures/no-extraneous/workspace-object/node_modules/root-dep/index.js
+++ b/tests/fixtures/no-extraneous/workspace-object/node_modules/root-dep/index.js
@@ -1,0 +1,1 @@
+export default {}

--- a/tests/fixtures/no-extraneous/workspace-object/node_modules/root-dep/package.json
+++ b/tests/fixtures/no-extraneous/workspace-object/node_modules/root-dep/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "root-dep",
+    "version": "0.0.0"
+}

--- a/tests/fixtures/no-extraneous/workspace-object/package.json
+++ b/tests/fixtures/no-extraneous/workspace-object/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "workspace-object-root",
+    "version": "0.0.0",
+    "private": true,
+    "workspaces": {
+        "packages": [
+            "@(packages|apps)/*"
+        ]
+    },
+    "dependencies": {
+        "root-dep": "0.0.0"
+    }
+}

--- a/tests/fixtures/no-extraneous/workspace-object/packages/app/package.json
+++ b/tests/fixtures/no-extraneous/workspace-object/packages/app/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "workspace-object-app",
+    "version": "0.0.0"
+}

--- a/tests/fixtures/no-extraneous/workspace-object/packages/app/src/index.js
+++ b/tests/fixtures/no-extraneous/workspace-object/packages/app/src/index.js
@@ -1,0 +1,3 @@
+import rootDep from "root-dep"
+
+rootDep()

--- a/tests/fixtures/no-extraneous/workspace/node_modules/root-dep/index.js
+++ b/tests/fixtures/no-extraneous/workspace/node_modules/root-dep/index.js
@@ -1,0 +1,1 @@
+export default {}

--- a/tests/fixtures/no-extraneous/workspace/node_modules/root-dep/package.json
+++ b/tests/fixtures/no-extraneous/workspace/node_modules/root-dep/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "root-dep",
+    "version": "0.0.0"
+}

--- a/tests/fixtures/no-extraneous/workspace/node_modules/root-dev-dep/index.js
+++ b/tests/fixtures/no-extraneous/workspace/node_modules/root-dev-dep/index.js
@@ -1,0 +1,1 @@
+export default {}

--- a/tests/fixtures/no-extraneous/workspace/node_modules/root-dev-dep/package.json
+++ b/tests/fixtures/no-extraneous/workspace/node_modules/root-dev-dep/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "root-dev-dep",
+    "version": "0.0.0"
+}

--- a/tests/fixtures/no-extraneous/workspace/package.json
+++ b/tests/fixtures/no-extraneous/workspace/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "workspace-root",
+    "version": "0.0.0",
+    "private": true,
+    "workspaces": [
+        "./{packages,apps}/*/"
+    ],
+    "dependencies": {
+        "root-dep": "0.0.0"
+    },
+    "devDependencies": {
+        "root-dev-dep": "0.0.0"
+    }
+}

--- a/tests/fixtures/no-extraneous/workspace/packages/app/package.json
+++ b/tests/fixtures/no-extraneous/workspace/packages/app/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "workspace-app",
+    "version": "0.0.0"
+}

--- a/tests/fixtures/no-extraneous/workspace/packages/app/src/index.js
+++ b/tests/fixtures/no-extraneous/workspace/packages/app/src/index.js
@@ -1,0 +1,3 @@
+import rootDep from "root-dep"
+
+rootDep()

--- a/tests/lib/rules/no-extraneous-import.js
+++ b/tests/lib/rules/no-extraneous-import.js
@@ -42,6 +42,11 @@ const ruleTester = new RuleTester({
         },
     },
 })
+const workspaceResolveSettings = {
+    n: {
+        tryExtensions: [".js", ".json", ".node", ".mjs", ".cjs"],
+    },
+}
 ruleTester.run("no-extraneous-import", rule, {
     valid: [
         {
@@ -79,6 +84,28 @@ ruleTester.run("no-extraneous-import", rule, {
         {
             filename: fixture("import-map/a.js"),
             code: "import '#b'",
+        },
+        {
+            filename: fixture("workspace/packages/app/src/index.js"),
+            code: "import rootDep from 'root-dep'",
+            settings: workspaceResolveSettings,
+        },
+        {
+            filename: fixture("workspace/packages/app/src/index.js"),
+            code: "import rootDevDep from 'root-dev-dep'",
+            settings: workspaceResolveSettings,
+        },
+        {
+            filename: fixture("workspace-object/packages/app/src/index.js"),
+            code: "import rootDep from 'root-dep'",
+            settings: workspaceResolveSettings,
+        },
+        {
+            filename: fixture(
+                "workspace-nested/inner/packages/app/src/index.js"
+            ),
+            code: "import rootDep from 'root-dep'",
+            settings: workspaceResolveSettings,
         },
 
         // missing packages are warned by no-missing-import
@@ -132,6 +159,22 @@ ruleTester.run("no-extraneous-import", rule, {
             filename: fixture("optionalDependencies/a.js"),
             code: "import bbb from 'bbb'",
             errors: ['"bbb" is extraneous.'],
+        },
+        {
+            filename: fixture(
+                "workspace-negated/packages/excluded/src/index.js"
+            ),
+            code: "import rootDep from 'root-dep'",
+            settings: workspaceResolveSettings,
+            errors: ['"root-dep" is extraneous.'],
+        },
+        {
+            filename: fixture(
+                "workspace-nested/inner/packages/app/src/index.js"
+            ),
+            code: "import outerDep from 'outer-dep'",
+            settings: workspaceResolveSettings,
+            errors: ['"outer-dep" is extraneous.'],
         },
 
         // import()

--- a/tests/lib/rules/no-extraneous-require.js
+++ b/tests/lib/rules/no-extraneous-require.js
@@ -21,6 +21,11 @@ function fixture(name) {
 }
 
 const tester = new RuleTester()
+const workspaceResolveSettings = {
+    n: {
+        tryExtensions: [".js", ".json", ".node", ".mjs", ".cjs"],
+    },
+}
 
 tester.run("no-extraneous-require", rule, {
     valid: [
@@ -64,6 +69,23 @@ tester.run("no-extraneous-require", rule, {
             filename: fixture("optionalDependencies/a.js"),
             code: "require('aaa')",
         },
+        {
+            filename: fixture("workspace/packages/app/src/index.js"),
+            code: "require('root-dep')",
+            settings: workspaceResolveSettings,
+        },
+        {
+            filename: fixture("workspace-object/packages/app/src/index.js"),
+            code: "require('root-dep')",
+            settings: workspaceResolveSettings,
+        },
+        {
+            filename: fixture(
+                "workspace-nested/inner/packages/app/src/index.js"
+            ),
+            code: "require('root-dep')",
+            settings: workspaceResolveSettings,
+        },
 
         // missing packages are warned by no-missing-require
         {
@@ -101,6 +123,22 @@ tester.run("no-extraneous-require", rule, {
             filename: fixture("optionalDependencies/a.js"),
             code: "require('bbb')",
             errors: ['"bbb" is extraneous.'],
+        },
+        {
+            filename: fixture(
+                "workspace-negated/packages/excluded/src/index.js"
+            ),
+            code: "require('root-dep')",
+            settings: workspaceResolveSettings,
+            errors: ['"root-dep" is extraneous.'],
+        },
+        {
+            filename: fixture(
+                "workspace-nested/inner/packages/app/src/index.js"
+            ),
+            code: "require('outer-dep')",
+            settings: workspaceResolveSettings,
+            errors: ['"outer-dep" is extraneous.'],
         },
         {
             filename: fixture("dependencies/a.js"),


### PR DESCRIPTION
Problem I saw:
`n/no-extraneous-import` could report a dependency as extraneous from a child workspace package even when that dependency was declared in the matching root workspace package.
That shared dependency lookup also affects `n/no-extraneous-require`, so the fix needed to stay in the common path.
What I changed:
I kept the nearest `package.json` as the main package source, then added a workspace-root fallback for packages that are inside a matching ancestor `package.json#workspaces` entry.
When the child package is part of that workspace root, the rule can now accept the root package's dependency buckets. This handles the supported workspace array/object forms, path normalization cases, negated patterns, and stops at the nearest matching workspace root.
I did not add `pnpm-workspace.yaml` support here.
How I checked it:
I confirmed the new import case failed before the fix with `"root-dep" is extraneous`.
Then I ran the focused import/require tests, which passed with 49 tests, and the full rule tests, which passed with 3045 passing and 3 pending.
I also ran:
npm run lint:js
npm run test:types
git diff --check
Pre-push hygiene is clean.
Closes #209
