### PR TITLE
Honor extension overrides after extensionless fallback paths

### DIFF
--- a/lib/rules/file-extension-in-import.js
+++ b/lib/rules/file-extension-in-import.js
@@ -9,13 +9,19 @@ import { convertTsExtensionToJs } from "../util/map-typescript-extension.js"
 import { getTryExtensions } from "../util/get-try-extensions.js"
 import { visitImport } from "../util/visit-import.js"
 
+/** TypeScript declaration files (`.d.ts`, `.d.mts`, `.d.cts`). */
+const DECLARATION_FILE_EXT = /\.d\.[mc]?ts$/
+
 /**
  * Get all file extensions of the files which have the same basename.
  * @param {string} filePath The path to the original file to check.
  * @param {string} [basename] Optional basename to use instead of deriving from filePath.
+ * @param {boolean} [excludeDeclarationFiles] Whether to skip declaration files
+ *     (`*.d.ts` etc.), which only describe types and never act as the runtime
+ *     implementation of an import.
  * @returns {string[]} File extensions.
  */
-function getExistingExtensions(filePath, basename) {
+function getExistingExtensions(filePath, basename, excludeDeclarationFiles) {
     const directory = path.dirname(filePath)
     if (basename == null) {
         const extension = path.extname(filePath)
@@ -25,7 +31,14 @@ function getExistingExtensions(filePath, basename) {
     try {
         return fs
             .readdirSync(directory)
-            .filter(filename => filename.startsWith(`${basename}.`))
+            .filter(
+                filename =>
+                    filename.startsWith(`${basename}.`) &&
+                    !(
+                        excludeDeclarationFiles &&
+                        DECLARATION_FILE_EXT.test(filename)
+                    )
+            )
             .map(filename => path.extname(filename))
     } catch {
         return []
@@ -130,11 +143,14 @@ export default {
                 fs.existsSync(filePath) && fs.statSync(filePath).isFile()
             if (!fileExists) {
                 // Use the full basename (e.g., "utils.client") since what path.extname
-                // thinks is an extension (e.g., ".client") may not be a real file extension
+                // thinks is an extension (e.g., ".client") may not be a real file extension.
+                // Declaration files are skipped: a lone "foo.d.ts" describes types for a
+                // runtime module, it is not a runtime ".ts" implementation of "./foo".
                 const importBasename = path.basename(name)
                 const extensions = getExistingExtensions(
                     filePath,
-                    importBasename
+                    importBasename,
+                    true
                 )
                 // Find the preferred extension based on tryExtensions order
                 const preferred = tryExtensions.find(ext =>

--- a/lib/rules/file-extension-in-import.js
+++ b/lib/rules/file-extension-in-import.js
@@ -122,11 +122,13 @@ export default {
 
             // If the file doesn't exist (or is a directory), the resolver may have returned
             // a fallback path. In this case, path.extname may return a "fake" extension
-            // (e.g., ".client" for "utils.client" when the actual file is "utils.client.ts").
+            // (e.g., ".client" for "utils.client" when the actual file is "utils.client.ts"),
+            // or no extension at all (e.g., for "print-hello" when the actual file is
+            // "print-hello.ts" and the resolver doesn't try TypeScript extensions).
             // We need to search for the actual file using the full basename from the import.
             const fileExists =
                 fs.existsSync(filePath) && fs.statSync(filePath).isFile()
-            if (actualExt !== "" && !fileExists) {
+            if (!fileExists) {
                 // Use the full basename (e.g., "utils.client") since what path.extname
                 // thinks is an extension (e.g., ".client") may not be a real file extension
                 const importBasename = path.basename(name)

--- a/tests/fixtures/file-extension-in-import/foo.d.ts
+++ b/tests/fixtures/file-extension-in-import/foo.d.ts
@@ -1,0 +1,1 @@
+export declare function foo(): void

--- a/tests/lib/rules/file-extension-in-import.js
+++ b/tests/lib/rules/file-extension-in-import.js
@@ -98,6 +98,14 @@ new RuleTester({
             options: ["always", { ".ts": "never", ".js": "never" }],
         },
         {
+            // A declaration file (foo.d.ts) is not a runtime ".ts"
+            // implementation, so a ".ts" override must not force a report
+            // through the fallback path.
+            filename: fixture("test.ts"),
+            code: "import './foo'",
+            options: ["never", { ".ts": "always" }],
+        },
+        {
             filename: fixture("test.js"),
             code: "import './a.js'",
             options: ["always"],
@@ -238,6 +246,16 @@ new RuleTester({
             code: "import './d'",
             options: ["never", { ".ts": "always" }],
             output: "import './d.js'",
+            errors: [{ messageId: "requireExt", data: { ext: ".js" } }],
+        },
+        {
+            // A declaration file (foo.d.ts) is not a runtime ".ts"
+            // implementation: the ".ts" override must not swallow the
+            // default-style report through the fallback path.
+            filename: fixture("test.ts"),
+            code: "import './foo'",
+            options: ["always", { ".ts": "never", ".js": "never" }],
+            output: "import './foo.js'",
             errors: [{ messageId: "requireExt", data: { ext: ".js" } }],
         },
         {

--- a/tests/lib/rules/file-extension-in-import.js
+++ b/tests/lib/rules/file-extension-in-import.js
@@ -89,6 +89,15 @@ new RuleTester({
             code: "import './d.js'",
         },
         {
+            // https://github.com/eslint-community/eslint-plugin-n/issues/405
+            // "./d" only resolves to "./d.ts", so the ".ts" override must
+            // apply even though the resolver falls back to an extensionless
+            // path.
+            filename: fixture("test.ts"),
+            code: "import './d'",
+            options: ["always", { ".ts": "never", ".js": "never" }],
+        },
+        {
             filename: fixture("test.js"),
             code: "import './a.js'",
             options: ["always"],
@@ -218,6 +227,16 @@ new RuleTester({
         {
             filename: fixture("test.ts"),
             code: "import './d'",
+            output: "import './d.js'",
+            errors: [{ messageId: "requireExt", data: { ext: ".js" } }],
+        },
+        {
+            // https://github.com/eslint-community/eslint-plugin-n/issues/405
+            // An extension override must also apply when the import resolves
+            // to a TypeScript file through the extensionless fallback path.
+            filename: fixture("test.ts"),
+            code: "import './d'",
+            options: ["never", { ".ts": "always" }],
             output: "import './d.js'",
             errors: [{ messageId: "requireExt", data: { ext: ".js" } }],
         },


### PR DESCRIPTION
`n/file-extension-in-import` could ignore configured `.ts` overrides when resolution fell back to an extensionless path for a real TypeScript file.
That showed up during TypeScript migrations as reports like requiring a `.js` extension for imports such as `./d` or `./print-hello`, even when `.ts` was configured as `never` or `always`.
This keeps the existing basename recovery path available when the fallback path has no extension, so the rule can still recover the real file extension before applying overrides.
I added two regression tests. They fail on master with the bogus `.js` report, then pass with the fix. I also ran the focused rule test with 64 passing, the full suite with 3059 passing and 3 pending, typecheck, lint, `git diff --check`, and branch hygiene.
Closes #405