### PR TITLE
feat: add `module.exports` for `require(esm)` interop

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,4 +45,10 @@ const configs = {
 }
 
 /** @type {ESLint.Plugin & { configs: Configs }} */
-export default Object.assign(base, { configs })
+const plugin = Object.assign(base, { configs })
+
+export {
+    plugin as default,
+    plugin as 'module.exports',
+}
+


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint Community adheres to the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This makes possible for CommonJS users to upgrade to v18 without making any changes due to `require(esm)` interop: https://nodejs.org/api/esm.html#commonjs-namespaces

I did a similar change for [`eslint-stylistic`](https://github.com/eslint-stylistic/eslint-stylistic/pull/700) last year.

#### What changes did you make? (Give an overview)

Added a second `module.exports` export in addition to the `default` one

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
