### PR TITLE
fix: ensure types have valid syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "lint:js": "eslint .",
         "new": "node scripts/new-rule",
         "postversion": "git push && git push --tags",
-        "prepack": "tsc --emitDeclarationOnly && ts-ignore-import 'types/**/*.d.ts' --allow=@eslint-community/eslint-utils --allow=semver --allow=get-tsconfig",
+        "prepack": "tsc --emitDeclarationOnly && node scripts/patch-types.js && ts-ignore-import 'types/**/*.d.ts' --allow=@eslint-community/eslint-utils --allow=semver --allow=get-tsconfig",
         "prepare": "husky",
         "preversion": "npm test",
         "test": "run-p lint:* test:types test:tests",

--- a/scripts/patch-types.js
+++ b/scripts/patch-types.js
@@ -1,0 +1,12 @@
+import fs from "fs"
+import path from "path"
+
+const filePath = path.resolve(import.meta.dirname, "../types/index.d.ts")
+
+// todo: this can be removed once https://github.com/microsoft/TypeScript/issues/63586 is fixed
+fs.writeFileSync(
+    filePath,
+    fs
+        .readFileSync(filePath, "utf8")
+        .replace("as module.exports", 'as "module.exports"')
+)


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint Community adheres to the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This works around a [TypeScript bug](https://github.com/microsoft/TypeScript/issues/63586) with using  `as 'module.exports'` in a JS file whereby the emitted declaration does not quote the `module.exports` making the syntax invalid.

#### What changes did you make? (Give an overview)

I've added a script to run after the types have been generated that adds the quoting around `module.exports` in the types to make it valid

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

https://github.com/microsoft/TypeScript/issues/63586
https://github.com/eslint-community/eslint-plugin-n/pull/542

#### Is there anything you'd like reviewers to focus on?
