### PR TITLE
Ignore HTTP imports in no-missing-import

### DIFF
--- a/lib/util/import-target.js
+++ b/lib/util/import-target.js
@@ -177,12 +177,12 @@ export class ImportTarget {
             return "data"
         }
 
-        if (/^(@[\w~-][\w.~-]*\/)?[\w~-][\w.~-]*/.test(this.name)) {
-            return "npm"
-        }
-
         if (/^https?:\/\//.test(this.name)) {
             return "http"
+        }
+
+        if (/^(@[\w~-][\w.~-]*\/)?[\w~-][\w.~-]*/.test(this.name)) {
+            return "npm"
         }
 
         return "unknown"
@@ -306,7 +306,10 @@ export class ImportTarget {
      * @returns {string | null} The resolved path.
      */
     getFilePath() {
-        if (this.moduleType === "data" && this.moduleStyle === "import") {
+        if (
+            (this.moduleType === "data" || this.moduleType === "http") &&
+            this.moduleStyle === "import"
+        ) {
             return this.name
         }
 

--- a/tests/lib/rules/no-missing-import.js
+++ b/tests/lib/rules/no-missing-import.js
@@ -369,6 +369,14 @@ ruleTester.run("no-missing-import", rule, {
             filename: fixture("test.js"),
             code: "import 'data:text/javascript,const x = 123;';",
         },
+        {
+            filename: fixture("test.js"),
+            code: "import 'https://example.com/module.js';",
+        },
+        {
+            filename: fixture("test.js"),
+            code: "import 'http://localhost/module.js';",
+        },
 
         // import()
         ...(DynamicImportSupported


### PR DESCRIPTION
HTTP(S) specifiers were being classified through the package-import path in `ImportTarget`, so `n/no-missing-import` could report them as missing files. The shared import-target utility now classifies them as URL imports before package matching and skips filesystem resolution for `http:` and `https:` imports.

The rule run passed with 78 cases. The full rules run passed with 3059 passing and 3 pending, along with ESLint and TypeScript checks. Fixes #65
