### PR TITLE
fix(no-callback-literal): report object, array, and template literals

### DIFF
--- a/lib/rules/no-callback-literal.js
+++ b/lib/rules/no-callback-literal.js
@@ -59,6 +59,10 @@ function couldBeError(node) {
             return true // possibly an error object.
         case "Literal":
             return node.value == null
+        case "ArrayExpression":
+        case "ObjectExpression":
+        case "TemplateLiteral":
+            return false
         case "AssignmentExpression":
             return couldBeError(node.right)
 

--- a/tests/lib/rules/no-callback-literal.js
+++ b/tests/lib/rules/no-callback-literal.js
@@ -106,6 +106,33 @@ ruleTester.run("no-callback-literal", rule, {
             ],
         },
         {
+            code: "cb({ a: 1 })",
+            errors: [
+                {
+                    message:
+                        "Unexpected literal in error position of callback.",
+                },
+            ],
+        },
+        {
+            code: "cb([])",
+            errors: [
+                {
+                    message:
+                        "Unexpected literal in error position of callback.",
+                },
+            ],
+        },
+        {
+            code: "cb(`message ${value}`)",
+            errors: [
+                {
+                    message:
+                        "Unexpected literal in error position of callback.",
+                },
+            ],
+        },
+        {
             code: "callback((a, 1), data)",
             errors: [
                 {


### PR DESCRIPTION
#### What is the purpose of this pull request?
fixes regression in `no-callback-literal` rule with objects, arrays and template literals. 

#### What changes did you make? (Give an overview)
added reporting on objects, arrays and template literals

#### Related Issues
https://github.com/eslint-community/eslint-plugin-n/pull/520#issuecomment-4650405274. 

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
