### PR TITLE
feat: implement `prefer-import/assert-strict` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ For [Shareable Configs](https://eslint.org/docs/latest/developer-guide/shareable
 | [prefer-global/timers](docs/rules/prefer-global/timers.md)                                   | enforce either global timer functions or `require("timers")`                          |      |    |    |
 | [prefer-global/url](docs/rules/prefer-global/url.md)                                         | enforce either `URL` or `require("url").URL`                                          |      |    |    |
 | [prefer-global/url-search-params](docs/rules/prefer-global/url-search-params.md)             | enforce either `URLSearchParams` or `require("url").URLSearchParams`                  |      |    |    |
-| [prefer-import/assert-strict](docs/rules/prefer-import/assert-strict.md)                     | enforce using `node:assert/strict` instead of `node:assert`.                          |      | 🔧 |    |
+| [prefer-import/assert-strict](docs/rules/prefer-import/assert-strict.md)                     | enforce using `node:assert/strict` instead of `node:assert`.                          |      |    |    |
 | [prefer-node-protocol](docs/rules/prefer-node-protocol.md)                                   | enforce using the `node:` protocol when importing Node.js builtin modules.            |      | 🔧 |    |
 | [prefer-promises/dns](docs/rules/prefer-promises/dns.md)                                     | enforce `require("dns").promises`                                                     |      |    |    |
 | [prefer-promises/fs](docs/rules/prefer-promises/fs.md)                                       | enforce `require("fs").promises`                                                      |      |    |    |

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ For [Shareable Configs](https://eslint.org/docs/latest/developer-guide/shareable
 | [prefer-global/timers](docs/rules/prefer-global/timers.md)                                   | enforce either global timer functions or `require("timers")`                          |      |    |    |
 | [prefer-global/url](docs/rules/prefer-global/url.md)                                         | enforce either `URL` or `require("url").URL`                                          |      |    |    |
 | [prefer-global/url-search-params](docs/rules/prefer-global/url-search-params.md)             | enforce either `URLSearchParams` or `require("url").URLSearchParams`                  |      |    |    |
+| [prefer-import/assert-strict](docs/rules/prefer-import/assert-strict.md)                     | enforce using `node:assert/strict` instead of `node:assert`.                          |      | 🔧 |    |
 | [prefer-node-protocol](docs/rules/prefer-node-protocol.md)                                   | enforce using the `node:` protocol when importing Node.js builtin modules.            |      | 🔧 |    |
 | [prefer-promises/dns](docs/rules/prefer-promises/dns.md)                                     | enforce `require("dns").promises`                                                     |      |    |    |
 | [prefer-promises/fs](docs/rules/prefer-promises/fs.md)                                       | enforce `require("fs").promises`                                                      |      |    |    |

--- a/docs/rules/prefer-import/assert-strict.md
+++ b/docs/rules/prefer-import/assert-strict.md
@@ -1,0 +1,40 @@
+# n/prefer-import/assert-strict
+
+📝 Enforce using `node:assert/strict` instead of `node:assert`.
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+
+## 📖 Rule Details
+
+The `node:assert` module exposes [legacy](https://nodejs.org/api/assert.html#legacy-assertion-mode), non-strict assertion methods. The `node:assert/strict` module changes the legacy methods to use strict equality.
+
+👍 Examples of **correct** code for this rule:
+
+```js
+/*eslint n/prefer-import/assert-strict: error */
+
+import assert from "node:assert/strict"
+import("node:assert/strict")
+const assert = require("node:assert/strict")
+
+// These forms already select strict assertion mode.
+import { strict as strictAssert } from "node:assert"
+const requiredAssert = require("node:assert").strict
+```
+
+👎 Examples of **incorrect** code for this rule:
+
+```js
+/*eslint n/prefer-import/assert-strict: error */
+
+import assert from "node:assert"
+import("node:assert")
+const assert = require("node:assert")
+```
+
+## 🔎 Implementation
+
+- [Rule source](../../../lib/rules/prefer-import/assert-strict.js)
+- [Test source](../../../tests/lib/rules/prefer-import/assert-strict.js)

--- a/docs/rules/prefer-import/assert-strict.md
+++ b/docs/rules/prefer-import/assert-strict.md
@@ -2,8 +2,6 @@
 
 📝 Enforce using `node:assert/strict` instead of `node:assert`.
 
-🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
-
 <!-- end auto-generated rule header -->
 
 ## 📖 Rule Details

--- a/lib/all-rules.js
+++ b/lib/all-rules.js
@@ -40,6 +40,7 @@ import preferGlobalTextEncoder from "./rules/prefer-global/text-encoder.js"
 import preferGlobalUrlSearchParams from "./rules/prefer-global/url-search-params.js"
 import preferGlobalUrl from "./rules/prefer-global/url.js"
 import preferGlobalTimers from "./rules/prefer-global/timers.js"
+import preferImportAssertStrict from "./rules/prefer-import/assert-strict.js"
 import preferNodeProtocol from "./rules/prefer-node-protocol.js"
 import preferPromisesDns from "./rules/prefer-promises/dns.js"
 import preferPromisesFs from "./rules/prefer-promises/fs.js"
@@ -86,6 +87,7 @@ const allRules = {
     "prefer-global/url-search-params": preferGlobalUrlSearchParams,
     "prefer-global/url": preferGlobalUrl,
     "prefer-global/timers": preferGlobalTimers,
+    "prefer-import/assert-strict": preferImportAssertStrict,
     "prefer-node-protocol": preferNodeProtocol,
     "prefer-promises/dns": preferPromisesDns,
     "prefer-promises/fs": preferPromisesFs,

--- a/lib/rules/prefer-import/assert-strict.js
+++ b/lib/rules/prefer-import/assert-strict.js
@@ -1,0 +1,164 @@
+/**
+ * @author baevm
+ * See LICENSE file in root directory for full license.
+ */
+
+const messageId = "preferAssertStrict"
+
+/**
+ * @param {import('estree').ImportDeclaration} node
+ * @returns {boolean}
+ */
+function importsOnlyStrict(node) {
+    return (
+        node.specifiers.length > 0 &&
+        node.specifiers.every(
+            specifier =>
+                specifier.type === "ImportSpecifier" &&
+                (specifier.imported.type === "Identifier"
+                    ? specifier.imported.name
+                    : specifier.imported.value) === "strict"
+        )
+    )
+}
+
+/**
+ * @param {import('estree').ExportNamedDeclaration} node
+ * @returns {boolean}
+ */
+function exportsOnlyStrict(node) {
+    return (
+        node.specifiers.length > 0 &&
+        node.specifiers.every(
+            specifier =>
+                specifier.type === "ExportSpecifier" &&
+                (specifier.local.type === "Identifier"
+                    ? specifier.local.name
+                    : specifier.local.value) === "strict"
+        )
+    )
+}
+
+/**
+ * @param {import('estree').Property | import('estree').RestElement} property
+ * @returns {boolean}
+ */
+function isStrictProperty(property) {
+    if (property.type !== "Property") {
+        return false
+    }
+
+    return property.computed
+        ? property.key.type === "Literal" && property.key.value === "strict"
+        : property.key.type === "Identifier" && property.key.name === "strict"
+}
+
+/**
+ * @param {import('estree').Pattern | import('estree').MemberExpression} node
+ * @returns {boolean}
+ */
+function accessesOnlyStrict(node) {
+    if (node.type === "MemberExpression") {
+        return node.computed
+            ? node.property.type === "Literal" &&
+                  node.property.value === "strict"
+            : node.property.type === "Identifier" &&
+                  node.property.name === "strict"
+    }
+
+    return (
+        node.type === "ObjectPattern" &&
+        node.properties.length > 0 &&
+        node.properties.every(isStrictProperty)
+    )
+}
+
+/**
+ * @param {import('estree').CallExpression & import('eslint').Rule.NodeParentExtension} node
+ * @returns {boolean}
+ */
+function requiresOnlyStrict(node) {
+    const { parent } = node
+
+    if (parent.type === "MemberExpression" && parent.object === node) {
+        return accessesOnlyStrict(parent)
+    }
+    if (parent.type === "VariableDeclarator" && parent.init === node) {
+        return accessesOnlyStrict(parent.id)
+    }
+    if (parent.type === "AssignmentExpression" && parent.right === node) {
+        return accessesOnlyStrict(parent.left)
+    }
+    return false
+}
+
+/**
+ * @param {import('estree').Node | null | undefined} node
+ * @param {import('eslint').Rule.RuleContext} context
+ */
+function checkSource(node, context) {
+    if (
+        node?.type !== "Literal" ||
+        typeof node.value !== "string" ||
+        node.value !== "node:assert"
+    ) {
+        return
+    }
+
+    context.report({
+        node,
+        messageId,
+        fix(fixer) {
+            const raw = context.sourceCode.getText(node)
+            const quote = raw[0]
+            return fixer.replaceText(node, `${quote}node:assert/strict${quote}`)
+        },
+    })
+}
+
+/** @type {import('../rule-module.js').RuleModule} */
+export default {
+    meta: {
+        docs: {
+            description:
+                "enforce using `node:assert/strict` instead of `node:assert`.",
+            recommended: false,
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-import/assert-strict.md",
+        },
+        fixable: "code",
+        messages: {
+            [messageId]: "Prefer `node:assert/strict` over `node:assert`.",
+        },
+        schema: [],
+        type: "suggestion",
+    },
+    create(context) {
+        return {
+            CallExpression(node) {
+                if (
+                    node.callee.type === "Identifier" &&
+                    node.callee.name === "require" &&
+                    !requiresOnlyStrict(node)
+                ) {
+                    checkSource(node.arguments[0], context)
+                }
+            },
+            ExportAllDeclaration(node) {
+                checkSource(node.source, context)
+            },
+            ExportNamedDeclaration(node) {
+                if (!exportsOnlyStrict(node)) {
+                    checkSource(node.source, context)
+                }
+            },
+            ImportDeclaration(node) {
+                if (!importsOnlyStrict(node)) {
+                    checkSource(node.source, context)
+                }
+            },
+            ImportExpression(node) {
+                checkSource(node.source, context)
+            },
+        }
+    },
+}

--- a/lib/rules/prefer-import/assert-strict.js
+++ b/lib/rules/prefer-import/assert-strict.js
@@ -108,11 +108,6 @@ function checkSource(node, context) {
     context.report({
         node,
         messageId,
-        fix(fixer) {
-            const raw = context.sourceCode.getText(node)
-            const quote = raw[0]
-            return fixer.replaceText(node, `${quote}node:assert/strict${quote}`)
-        },
     })
 }
 
@@ -125,7 +120,6 @@ export default {
             recommended: false,
             url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-import/assert-strict.md",
         },
-        fixable: "code",
         messages: {
             [messageId]: "Prefer `node:assert/strict` over `node:assert`.",
         },

--- a/tests/lib/rules/prefer-import/assert-strict.js
+++ b/tests/lib/rules/prefer-import/assert-strict.js
@@ -38,67 +38,54 @@ new RuleTester({
     invalid: [
         {
             code: 'import assert from "node:assert";',
-            output: 'import assert from "node:assert/strict";',
             errors: [{ messageId: "preferAssertStrict" }],
         },
         {
             code: "import * as assert from 'node:assert';",
-            output: "import * as assert from 'node:assert/strict';",
             errors: [{ messageId: "preferAssertStrict" }],
         },
         {
             code: 'import "node:assert";',
-            output: 'import "node:assert/strict";',
             errors: [{ messageId: "preferAssertStrict" }],
         },
         {
             code: 'import assert, { strict } from "node:assert";',
-            output: 'import assert, { strict } from "node:assert/strict";',
             errors: [{ messageId: "preferAssertStrict" }],
         },
         {
             code: 'import { strict, equal } from "node:assert";',
-            output: 'import { strict, equal } from "node:assert/strict";',
             errors: [{ messageId: "preferAssertStrict" }],
         },
         {
             code: 'export { default as assert } from "node:assert";',
-            output: 'export { default as assert } from "node:assert/strict";',
             errors: [{ messageId: "preferAssertStrict" }],
         },
         {
             code: 'export { strict, equal } from "node:assert";',
-            output: 'export { strict, equal } from "node:assert/strict";',
             errors: [{ messageId: "preferAssertStrict" }],
         },
         {
             code: 'export * from "node:assert";',
-            output: 'export * from "node:assert/strict";',
             errors: [{ messageId: "preferAssertStrict" }],
         },
         {
             code: 'import("node:assert");',
-            output: 'import("node:assert/strict");',
             errors: [{ messageId: "preferAssertStrict" }],
         },
         {
             code: 'require("node:assert");',
-            output: 'require("node:assert/strict");',
             errors: [{ messageId: "preferAssertStrict" }],
         },
         {
             code: 'require("node:assert", extra);',
-            output: 'require("node:assert/strict", extra);',
             errors: [{ messageId: "preferAssertStrict" }],
         },
         {
             code: 'const { strict, equal } = require("node:assert");',
-            output: 'const { strict, equal } = require("node:assert/strict");',
             errors: [{ messageId: "preferAssertStrict" }],
         },
         {
             code: 'require("node:\\u0061ssert");',
-            output: 'require("node:assert/strict");',
             errors: [{ messageId: "preferAssertStrict" }],
         },
     ],

--- a/tests/lib/rules/prefer-import/assert-strict.js
+++ b/tests/lib/rules/prefer-import/assert-strict.js
@@ -1,0 +1,110 @@
+/**
+ * @author baevm
+ * See LICENSE file in root directory for full license.
+ */
+
+import { RuleTester } from "#test-helpers"
+import rule from "../../../../lib/rules/prefer-import/assert-strict.js"
+
+new RuleTester({
+    languageOptions: {
+        ecmaVersion: 2025,
+        sourceType: "module",
+    },
+}).run("prefer-import/assert-strict", rule, {
+    valid: [
+        'import assert from "node:assert/strict";',
+        'import assert from "assert";',
+        'import assert from "node:assert/assert";',
+        'import assert from "another-assert";',
+        'import { strict } from "node:assert";',
+        'import { strict as assert } from "node:assert";',
+        'import { strict, strict as assert } from "node:assert";',
+        'export { strict } from "node:assert";',
+        'export { strict as assert } from "node:assert";',
+        'export { strict, strict as assert } from "node:assert";',
+        'import("node:assert/strict");',
+        'require("node:assert/strict");',
+        'const assert = require("node:assert").strict;',
+        'const assert = require("node:assert")["strict"];',
+        'const { strict } = require("node:assert");',
+        'const { strict: assert } = require("node:assert");',
+        'const { ["strict"]: assert } = require("node:assert");',
+        '({ strict: assert } = require("node:assert"));',
+        'notRequire("node:assert");',
+        "require(`node:assert`);",
+        "require(moduleName);",
+    ],
+    invalid: [
+        {
+            code: 'import assert from "node:assert";',
+            output: 'import assert from "node:assert/strict";',
+            errors: [{ messageId: "preferAssertStrict" }],
+        },
+        {
+            code: "import * as assert from 'node:assert';",
+            output: "import * as assert from 'node:assert/strict';",
+            errors: [{ messageId: "preferAssertStrict" }],
+        },
+        {
+            code: 'import "node:assert";',
+            output: 'import "node:assert/strict";',
+            errors: [{ messageId: "preferAssertStrict" }],
+        },
+        {
+            code: 'import assert, { strict } from "node:assert";',
+            output: 'import assert, { strict } from "node:assert/strict";',
+            errors: [{ messageId: "preferAssertStrict" }],
+        },
+        {
+            code: 'import { strict, equal } from "node:assert";',
+            output: 'import { strict, equal } from "node:assert/strict";',
+            errors: [{ messageId: "preferAssertStrict" }],
+        },
+        {
+            code: 'export { default as assert } from "node:assert";',
+            output: 'export { default as assert } from "node:assert/strict";',
+            errors: [{ messageId: "preferAssertStrict" }],
+        },
+        {
+            code: 'export { strict, equal } from "node:assert";',
+            output: 'export { strict, equal } from "node:assert/strict";',
+            errors: [{ messageId: "preferAssertStrict" }],
+        },
+        {
+            code: 'export * from "node:assert";',
+            output: 'export * from "node:assert/strict";',
+            errors: [{ messageId: "preferAssertStrict" }],
+        },
+        {
+            code: 'import("node:assert");',
+            output: 'import("node:assert/strict");',
+            errors: [{ messageId: "preferAssertStrict" }],
+        },
+        {
+            code: 'import("node:assert", options);',
+            output: 'import("node:assert/strict", options);',
+            errors: [{ messageId: "preferAssertStrict" }],
+        },
+        {
+            code: 'require("node:assert");',
+            output: 'require("node:assert/strict");',
+            errors: [{ messageId: "preferAssertStrict" }],
+        },
+        {
+            code: 'require("node:assert", extra);',
+            output: 'require("node:assert/strict", extra);',
+            errors: [{ messageId: "preferAssertStrict" }],
+        },
+        {
+            code: 'const { strict, equal } = require("node:assert");',
+            output: 'const { strict, equal } = require("node:assert/strict");',
+            errors: [{ messageId: "preferAssertStrict" }],
+        },
+        {
+            code: 'require("node:\\u0061ssert");',
+            output: 'require("node:assert/strict");',
+            errors: [{ messageId: "preferAssertStrict" }],
+        },
+    ],
+})

--- a/tests/lib/rules/prefer-import/assert-strict.js
+++ b/tests/lib/rules/prefer-import/assert-strict.js
@@ -8,7 +8,7 @@ import rule from "../../../../lib/rules/prefer-import/assert-strict.js"
 
 new RuleTester({
     languageOptions: {
-        ecmaVersion: 2025,
+        ecmaVersion: 2020,
         sourceType: "module",
     },
 }).run("prefer-import/assert-strict", rule, {
@@ -79,11 +79,6 @@ new RuleTester({
         {
             code: 'import("node:assert");',
             output: 'import("node:assert/strict");',
-            errors: [{ messageId: "preferAssertStrict" }],
-        },
-        {
-            code: 'import("node:assert", options);',
-            output: 'import("node:assert/strict", options);',
             errors: [{ messageId: "preferAssertStrict" }],
         },
         {


### PR DESCRIPTION
#### What is the purpose of this pull request?
this PR implements `prefer-import/assert-strict` rule from issue #59. I reused some tests from biome rule and also added some new ones.


#### What changes did you make? (Give an overview)
implemented `prefer-import/assert-strict` rule

#### Related Issues
closes #59

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
I used rule name suggested in the issue, but maybe it should be renamed to something like `assert/prefer-strict`, since more rules related to node assert have been suggested? Im also open to changing whether this rule should be recommended ~~and whether it should provide an autofix~~