### PR TITLE
feat: add prefer-process-get-builtin-module rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ For [Shareable Configs](https://eslint.org/docs/latest/developer-guide/shareable
 | [prefer-global/url](docs/rules/prefer-global/url.md)                                         | enforce either `URL` or `require("url").URL`                                          |      |    |    |
 | [prefer-global/url-search-params](docs/rules/prefer-global/url-search-params.md)             | enforce either `URLSearchParams` or `require("url").URLSearchParams`                  |      |    |    |
 | [prefer-node-protocol](docs/rules/prefer-node-protocol.md)                                   | enforce using the `node:` protocol when importing Node.js builtin modules.            |      | 🔧 |    |
+| [prefer-process-get-builtin-module](docs/rules/prefer-process-get-builtin-module.md)         | enforce using `process.getBuiltinModule()` to load Node.js built-in modules           |      |    |    |
 | [prefer-promises/dns](docs/rules/prefer-promises/dns.md)                                     | enforce `require("dns").promises`                                                     |      |    |    |
 | [prefer-promises/fs](docs/rules/prefer-promises/fs.md)                                       | enforce `require("fs").promises`                                                      |      |    |    |
 | [process-exit-as-throw](docs/rules/process-exit-as-throw.md)                                 | require that `process.exit()` expressions use the same code path as `throw`           | 🟢 ✅ |    |    |

--- a/docs/rules/prefer-process-get-builtin-module.md
+++ b/docs/rules/prefer-process-get-builtin-module.md
@@ -1,0 +1,76 @@
+# n/prefer-process-get-builtin-module
+
+📝 Enforce using `process.getBuiltinModule()` to load Node.js built-in modules.
+
+<!-- end auto-generated rule header -->
+
+Node.js exposes built-in modules synchronously through `process.getBuiltinModule()`.
+In ES modules, this avoids creating a `require` function solely to access a
+built-in module. It also communicates that the requested module is built into
+Node.js.
+
+This API is available starting in Node.js 20.16.0 on the 20.x release line and
+in Node.js 22.3.0 or later.
+
+## 📖 Rule Details
+
+This rule reports calls to `require()` for built-in modules and awaited dynamic
+imports of built-in modules. It ignores non-built-in modules, dynamic imports
+that are not awaited directly, arbitrary functions named `require`, and
+references where `process` is shadowed. A local `require` created with
+`createRequire()` from `node:module` is recognized.
+
+This rule is not automatically fixable. An awaited dynamic import returns an
+ES module namespace object, while `process.getBuiltinModule()` returns the
+underlying built-in exports object. Review how the loaded module is used when
+applying the suggested replacement.
+
+👍 Examples of **correct** code for this rule:
+
+```js
+/*eslint n/prefer-process-get-builtin-module: error */
+
+const fs = process.getBuiltinModule("node:fs")
+const eslint = require("eslint")
+const lazyFs = import("node:fs")
+```
+
+👎 Examples of **incorrect** code for this rule:
+
+```js
+/*eslint n/prefer-process-get-builtin-module: error */
+
+const fs = require("node:fs")
+const promises = await import("node:fs/promises")
+```
+
+### Configured Node.js version range
+
+[Configured Node.js version range](../../README.md#configured-nodejs-version-range)
+
+### Options
+
+```json
+{
+    "n/prefer-process-get-builtin-module": [
+        "error",
+        {
+            "version": ">=22.3.0"
+        }
+    ]
+}
+```
+
+#### version
+
+This rule reads the [`engines`] field of `package.json`. You can override that
+range with the `version` option, which accepts any valid
+[`node-semver` range](https://github.com/npm/node-semver#range-grammar).
+
+The rule does not report when the configured range includes Node.js versions
+without `process.getBuiltinModule()`.
+
+## 🔎 Implementation
+
+- [Rule source](../../lib/rules/prefer-process-get-builtin-module.js)
+- [Test source](../../tests/lib/rules/prefer-process-get-builtin-module.js)

--- a/lib/all-rules.js
+++ b/lib/all-rules.js
@@ -41,6 +41,7 @@ import preferGlobalUrlSearchParams from "./rules/prefer-global/url-search-params
 import preferGlobalUrl from "./rules/prefer-global/url.js"
 import preferGlobalTimers from "./rules/prefer-global/timers.js"
 import preferNodeProtocol from "./rules/prefer-node-protocol.js"
+import preferProcessGetBuiltinModule from "./rules/prefer-process-get-builtin-module.js"
 import preferPromisesDns from "./rules/prefer-promises/dns.js"
 import preferPromisesFs from "./rules/prefer-promises/fs.js"
 import processExitAsThrow from "./rules/process-exit-as-throw.js"
@@ -87,6 +88,7 @@ const allRules = {
     "prefer-global/url": preferGlobalUrl,
     "prefer-global/timers": preferGlobalTimers,
     "prefer-node-protocol": preferNodeProtocol,
+    "prefer-process-get-builtin-module": preferProcessGetBuiltinModule,
     "prefer-promises/dns": preferPromisesDns,
     "prefer-promises/fs": preferPromisesFs,
     "process-exit-as-throw": processExitAsThrow,

--- a/lib/rules/prefer-process-get-builtin-module.js
+++ b/lib/rules/prefer-process-get-builtin-module.js
@@ -1,0 +1,164 @@
+/**
+ * @author ColumbusLabs
+ * See LICENSE file in root directory for full license.
+ */
+
+import { isBuiltin } from "node:module"
+import {
+    findVariable,
+    getStringIfConstant,
+} from "@eslint-community/eslint-utils"
+import { Range, subset } from "semver"
+import { getConfiguredNodeVersion } from "../util/get-configured-node-version.js"
+import { schema as configuredNodeVersionSchema } from "../util/get-configured-node-version.js"
+
+const supportedRange = new Range("^20.16.0 || >=22.3.0")
+
+/**
+ * @param {import("eslint").Rule.RuleContext} context
+ * @param {import("estree").Node} node
+ * @returns {boolean}
+ */
+function isProcessShadowed(context, node) {
+    const scope = context.sourceCode.getScope(node)
+    const variable = findVariable(scope, "process")
+    return Boolean(variable?.defs.length)
+}
+
+/**
+ * @param {import("eslint").Rule.RuleContext} context
+ * @param {import("estree").Identifier} node
+ * @returns {boolean}
+ */
+function isCreateRequireImport(context, node) {
+    const variable = findVariable(context.sourceCode.getScope(node), node)
+    return Boolean(
+        variable?.defs.some(
+            definition =>
+                definition.type === "ImportBinding" &&
+                definition.node.type === "ImportSpecifier" &&
+                definition.node.imported.type === "Identifier" &&
+                definition.node.imported.name === "createRequire" &&
+                (definition.parent.source.value === "node:module" ||
+                    definition.parent.source.value === "module")
+        )
+    )
+}
+
+/**
+ * @param {import("eslint").Rule.RuleContext} context
+ * @param {import("estree").Identifier} node
+ * @returns {boolean}
+ */
+function isNodeRequire(context, node) {
+    const variable = findVariable(context.sourceCode.getScope(node), node)
+    if (variable == null || variable.defs.length === 0) {
+        return true
+    }
+
+    return variable.defs.some(definition => {
+        if (
+            definition.type !== "Variable" ||
+            definition.node.type !== "VariableDeclarator" ||
+            definition.parent.type !== "VariableDeclaration" ||
+            definition.parent.kind !== "const" ||
+            definition.node.init?.type !== "CallExpression" ||
+            definition.node.init.callee.type !== "Identifier"
+        ) {
+            return false
+        }
+        return isCreateRequireImport(context, definition.node.init.callee)
+    })
+}
+
+/**
+ * @param {import("estree").Node | null | undefined} node
+ * @returns {boolean}
+ */
+function isBuiltinModuleName(node) {
+    if (node == null || node.type === "SpreadElement") {
+        return false
+    }
+    const name = getStringIfConstant(node)
+    return typeof name === "string" && isBuiltin(name)
+}
+
+/** @type {import("./rule-module.js").RuleModule} */
+export default {
+    meta: {
+        docs: {
+            description:
+                "enforce using `process.getBuiltinModule()` to load Node.js built-in modules",
+            recommended: false,
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-process-get-builtin-module.md",
+        },
+        messages: {
+            preferProcessGetBuiltinModule:
+                "Prefer `process.getBuiltinModule()` over `{{method}}()` for Node.js built-in modules.",
+        },
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    version: configuredNodeVersionSchema,
+                },
+                additionalProperties: false,
+            },
+        ],
+        type: "suggestion",
+    },
+    create(context) {
+        if (!subset(getConfiguredNodeVersion(context), supportedRange)) {
+            return {}
+        }
+
+        /**
+         * @param {import("estree").CallExpression} node
+         */
+        function reportRequire(node) {
+            if (
+                node.callee.type !== "Identifier" ||
+                node.callee.name !== "require" ||
+                !isNodeRequire(context, node.callee) ||
+                ("optional" in node && node.optional) ||
+                node.arguments.length !== 1 ||
+                !isBuiltinModuleName(node.arguments[0]) ||
+                isProcessShadowed(context, node)
+            ) {
+                return
+            }
+
+            context.report({
+                node,
+                messageId: "preferProcessGetBuiltinModule",
+                data: { method: "require" },
+            })
+        }
+
+        /**
+         * @param {import("estree").AwaitExpression} node
+         */
+        function reportImport(node) {
+            const importExpression = node.argument
+            if (
+                importExpression.type !== "ImportExpression" ||
+                importExpression.options != null ||
+                !isBuiltinModuleName(importExpression.source) ||
+                isProcessShadowed(context, node)
+            ) {
+                return
+            }
+
+            context.report({
+                node,
+                messageId: "preferProcessGetBuiltinModule",
+                data: { method: "import" },
+            })
+        }
+
+        return {
+            AwaitExpression: reportImport,
+            CallExpression: reportRequire,
+        }
+    },
+}

--- a/tests/lib/rules/prefer-process-get-builtin-module.js
+++ b/tests/lib/rules/prefer-process-get-builtin-module.js
@@ -1,0 +1,166 @@
+/**
+ * @author ColumbusLabs
+ * See LICENSE file in root directory for full license.
+ */
+
+import { RuleTester } from "#test-helpers"
+import rule from "../../../lib/rules/prefer-process-get-builtin-module.js"
+
+new RuleTester({
+    languageOptions: {
+        ecmaVersion: 2022,
+        sourceType: "module",
+    },
+}).run("prefer-process-get-builtin-module", rule, {
+    valid: [
+        'const fs = process.getBuiltinModule("node:fs")',
+        'const fs = require("eslint")',
+        "const fs = require(name)",
+        "const fs = require(`node:${name}`)",
+        'const fs = require("node:fs", extra)',
+        'const fs = require?.("node:fs")',
+        'const fs = require(...["node:fs"])',
+        'const fs = other.require("node:fs")',
+        'const fs = import("node:fs")',
+        "const fs = await import(name)",
+        'const fs = await import("eslint")',
+        {
+            code: 'const fs = require("node:fs")',
+            options: [{ version: "20.15.1" }],
+        },
+        {
+            code: 'const fs = await import("node:fs")',
+            options: [{ version: "22.2.0" }],
+        },
+        {
+            code: 'const fs = require("node:fs")',
+            options: [{ version: "21.7.3" }],
+        },
+        {
+            code: 'function load(process) { return require("node:fs") }',
+            languageOptions: { sourceType: "script" },
+        },
+        {
+            code: 'async function load(process) { return await import("node:fs") }',
+        },
+        'const process = {}; const fs = require("node:fs")',
+        {
+            code: 'function load(require) { return require("node:fs") }',
+            languageOptions: { sourceType: "script" },
+        },
+        'const createRequire = () => () => {}; const require = createRequire(); require("node:fs")',
+        'import { createRequire } from "node:module"; let require = createRequire(import.meta.url); require = () => ({}); require("node:fs")',
+    ],
+    invalid: [
+        {
+            code: 'const fs = require("node:fs")',
+            errors: [
+                {
+                    messageId: "preferProcessGetBuiltinModule",
+                    data: { method: "require" },
+                },
+            ],
+        },
+        {
+            code: 'const fs = require("fs/promises")',
+            errors: [
+                {
+                    messageId: "preferProcessGetBuiltinModule",
+                    data: { method: "require" },
+                },
+            ],
+        },
+        {
+            code: 'const fs = require("node:" + "fs")',
+            errors: [
+                {
+                    messageId: "preferProcessGetBuiltinModule",
+                    data: { method: "require" },
+                },
+            ],
+        },
+        {
+            code: "const fs = require(`node:fs`)",
+            errors: [
+                {
+                    messageId: "preferProcessGetBuiltinModule",
+                    data: { method: "require" },
+                },
+            ],
+        },
+        {
+            code: 'const fs = await import("node:fs")',
+            errors: [
+                {
+                    messageId: "preferProcessGetBuiltinModule",
+                    data: { method: "import" },
+                },
+            ],
+        },
+        {
+            code: 'const fs = await import("fs/promises")',
+            errors: [
+                {
+                    messageId: "preferProcessGetBuiltinModule",
+                    data: { method: "import" },
+                },
+            ],
+        },
+        {
+            code: 'const fs = await /* keep */ import("node:fs")',
+            errors: [
+                {
+                    messageId: "preferProcessGetBuiltinModule",
+                    data: { method: "import" },
+                },
+            ],
+        },
+        {
+            code: 'const fs = await import(/* keep */ "node:fs")',
+            errors: [
+                {
+                    messageId: "preferProcessGetBuiltinModule",
+                    data: { method: "import" },
+                },
+            ],
+        },
+        {
+            code: 'const fs = require("node:fs")',
+            options: [{ version: "20.16.0" }],
+            errors: [
+                {
+                    messageId: "preferProcessGetBuiltinModule",
+                    data: { method: "require" },
+                },
+            ],
+        },
+        {
+            code: 'const fs = await import("node:fs")',
+            options: [{ version: "22.3.0" }],
+            errors: [
+                {
+                    messageId: "preferProcessGetBuiltinModule",
+                    data: { method: "import" },
+                },
+            ],
+        },
+        {
+            code: 'import { createRequire } from "node:module"; const require = createRequire(import.meta.url); require("node:fs")',
+            errors: [
+                {
+                    messageId: "preferProcessGetBuiltinModule",
+                    data: { method: "require" },
+                },
+            ],
+        },
+        {
+            code: 'import { createRequire as makeRequire } from "module"; const require = makeRequire(import.meta.url); require("node:fs")',
+            errors: [
+                {
+                    messageId: "preferProcessGetBuiltinModule",
+                    data: { method: "require" },
+                },
+            ],
+        },
+    ],
+})


### PR DESCRIPTION
Closes #475.

## Summary
- add prefer-process-get-builtin-module for global require(), createRequire bindings, and directly awaited built-in imports
- gate reports to Node.js ^20.16.0 or >=22.3.0
- ignore arbitrary/shadowed/reassigned require and process bindings
- keep the rule report-only because module namespace and require cache semantics can differ
- add tests, documentation, registry entry, and generated README metadata

## Validation
- npm test (3,094 passing, 3 pending)
- ESLint, TypeScript, Markdown, and generated-doc checks
- plugin registry readback
- git diff --check