### PR TITLE
chore: rename default export `n`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,8 @@ const configs = {
     "flat/all": { plugins: { n: base }, ...allRulesFlatConfig },
 }
 
+// Name the variable `n` for the default export so that it has the same name
+// when the plugin is imported.
 /** @type {ESLint.Plugin & { configs: Configs }} */
 const n = Object.assign(base, { configs })
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,10 +45,10 @@ const configs = {
 }
 
 /** @type {ESLint.Plugin & { configs: Configs }} */
-const plugin = Object.assign(base, { configs })
+const n = Object.assign(base, { configs })
 
 export {
-    plugin as default,
-    plugin as 'module.exports',
+    n as default,
+    n as 'module.exports',
 }
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint Community adheres to the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

When importing the default export, it's recommended to use the same name as the exported variable (cf. [_import-x/no-rename-default_](https://github.com/un-ts/eslint-plugin-import-x/blob/v4.17.1/docs/rules/no-rename-default.md)).

The variable name exported by _eslint-plugin-n_ is `plugin`. With the following file:

```javascript
import n from "eslint-plugin-n";

export default [
    {
        plugins: { n },
        extends: ["n/recommended-module"],
    }
];
```

ESLint and _import-x/no-rename-default_ report this error:

> Caution: `index.js` has a default export `plugin`. This imports `plugin` as `n`. Check if you meant to write `import plugin from 'eslint-plugin-n'` instead.

#### What changes did you make? (Give an overview)

With this pull request, we will be able to use the name `n`