### PR TITLE
fix: support brace expansion and extglobs in package files

### DIFF
--- a/lib/util/get-npmignore.js
+++ b/lib/util/get-npmignore.js
@@ -92,12 +92,85 @@ function filterNeverIgnoredFiles(packageJson) {
  * @param {string} pattern A pattern from the package.json files field.
  * @returns {(filePath: string) => boolean} A function that checks whether a path matches the pattern.
  */
-function createFilesMatcher(pattern) {
-    const matchers = [pattern, `${pattern}/**`].map(
-        value => globrex(value, { extended: true, globstar: true }).regex
-    )
+function createFilesMatcher(pattern, matchBasename = false) {
+    const patterns = [pattern, `${pattern}/**`]
+    if (matchBasename && !pattern.includes("/")) {
+        patterns.push(`**/${pattern}`)
+    }
+
+    const matchers = expandSequenceBraces(patterns).map(value => {
+        const regex = globrex(value, { extended: true, globstar: true }).regex
+        return new RegExp(regex.source, `${regex.flags}i`)
+    })
 
     return filePath => matchers.some(matcher => matcher.test(filePath))
+}
+
+/**
+ * Expands the numeric and alphabetic brace sequences accepted by npm's files
+ * matcher. Other brace expressions are left for globrex to handle.
+ *
+ * @param {string[]} patterns Patterns to expand.
+ * @returns {string[]} Expanded patterns.
+ */
+function expandSequenceBraces(patterns) {
+    const sequence = /\{(-?\d+|[a-z])\.\.(-?\d+|[a-z])(?:\.\.(-?\d+))?\}/iu
+    const expanded = []
+
+    for (const pattern of patterns) {
+        const match = sequence.exec(pattern)
+        if (match == null) {
+            expanded.push(pattern)
+            continue
+        }
+
+        const [, start, end, rawStep] = match
+        if (start == null || end == null) {
+            expanded.push(pattern)
+            continue
+        }
+        const numeric = /^-?\d+$/u.test(start) && /^-?\d+$/u.test(end)
+        const alphabetic = /^[a-z]$/iu.test(start) && /^[a-z]$/iu.test(end)
+        const step = Number(rawStep || 1)
+        if ((!numeric && !alphabetic) || !Number.isInteger(step) || step <= 0) {
+            expanded.push(pattern)
+            continue
+        }
+
+        const startValue = numeric ? Number(start) : start.codePointAt(0)
+        const endValue = numeric ? Number(end) : end.codePointAt(0)
+        if (startValue == null || endValue == null) {
+            expanded.push(pattern)
+            continue
+        }
+        const direction = startValue <= endValue ? 1 : -1
+        const width = numeric && /^0\d/u.test(start) ? start.length : 0
+        /**
+         * @param {number} value A value in the sequence.
+         * @returns {string} The corresponding replacement text.
+         */
+        const replacement = value => {
+            if (!numeric) {
+                return String.fromCodePoint(value)
+            }
+            const text = String(value)
+            return width > 0 ? text.padStart(width, "0") : text
+        }
+
+        const prefix = pattern.slice(0, match.index)
+        const suffix = pattern.slice(match.index + match[0].length)
+        const replacements = []
+        for (
+            let value = startValue;
+            direction > 0 ? value <= endValue : value >= endValue;
+            value += direction * step
+        ) {
+            replacements.push(`${prefix}${replacement(value)}${suffix}`)
+        }
+        expanded.push(...expandSequenceBraces(replacements))
+    }
+
+    return expanded
 }
 
 /**
@@ -130,14 +203,14 @@ function parseWhiteList(files) {
 
     for (const file of files) {
         if (typeof file === "string" && file) {
+            const isNegated = file.startsWith("!")
             const body = path.posix
                 .normalize(file.replace(/^[!/]/u, ""))
                 .replace(/\/+$/u, "")
 
-            const isNegated = file.startsWith("!")
             if (hasExtendedGlob(body)) {
                 if (isNegated) {
-                    exclude.push(createFilesMatcher(body))
+                    exclude.push(createFilesMatcher(body, true))
                 } else {
                     include.push(createFilesMatcher(body))
                 }

--- a/lib/util/get-npmignore.js
+++ b/lib/util/get-npmignore.js
@@ -5,6 +5,7 @@
 
 import fs from "node:fs"
 import path from "node:path"
+import globrex from "globrex"
 import ignoreModule from "ignore"
 import { Cache } from "./cache.js"
 import { exists } from "./exists.js"
@@ -85,6 +86,31 @@ function filterNeverIgnoredFiles(packageJson) {
 }
 
 /**
+ * Creates a function that checks whether a path is matched by an npm files
+ * pattern or a file below a matched directory.
+ *
+ * @param {string} pattern A pattern from the package.json files field.
+ * @returns {(filePath: string) => boolean} A function that checks whether a path matches the pattern.
+ */
+function createFilesMatcher(pattern) {
+    const matchers = [pattern, `${pattern}/**`].map(
+        value => globrex(value, { extended: true, globstar: true }).regex
+    )
+
+    return filePath => matchers.some(matcher => matcher.test(filePath))
+}
+
+/**
+ * Checks whether a pattern requires extended glob matching beyond gitignore.
+ *
+ * @param {string} pattern A pattern from the package.json files field.
+ * @returns {boolean} Whether the pattern uses brace expansion or extglob syntax.
+ */
+function hasExtendedGlob(pattern) {
+    return /[{}]|[@+?!*]\(/u.test(pattern)
+}
+
+/**
  * Creates a function which checks whether or not a given file should be ignored.
  *
  * @param {unknown} files - File names of whitelist.
@@ -97,7 +123,10 @@ function parseWhiteList(files) {
 
     const ig = ignore()
     const igN = ignore()
-    let hasN = false
+    /** @type {Array<(filePath: string) => boolean>} */
+    const include = []
+    /** @type {Array<(filePath: string) => boolean>} */
+    const exclude = []
 
     for (const file of files) {
         if (typeof file === "string" && file) {
@@ -105,10 +134,16 @@ function parseWhiteList(files) {
                 .normalize(file.replace(/^[!/]/u, ""))
                 .replace(/\/+$/u, "")
 
-            if (file.startsWith("!")) {
+            const isNegated = file.startsWith("!")
+            if (hasExtendedGlob(body)) {
+                if (isNegated) {
+                    exclude.push(createFilesMatcher(body))
+                } else {
+                    include.push(createFilesMatcher(body))
+                }
+            } else if (isNegated) {
                 igN.add(`${body}`)
                 igN.add(`${body}/**`)
-                hasN = true
             } else {
                 ig.add(`/${body}`)
                 ig.add(`/${body}/**`)
@@ -116,9 +151,18 @@ function parseWhiteList(files) {
         }
     }
 
-    return hasN
-        ? or(ig.createFilter(), not(igN.createFilter()))
-        : ig.createFilter()
+    const includeFilter = ig.createFilter()
+    const excludeFilter = igN.createFilter()
+    return filePath => {
+        const matchesInclude = include.some(matcher => matcher(filePath))
+        const matchesExclude = exclude.some(matcher => matcher(filePath))
+
+        return (
+            (includeFilter(filePath) && !matchesInclude) ||
+            !excludeFilter(filePath) ||
+            matchesExclude
+        )
+    }
 }
 
 /**

--- a/tests/fixtures/no-unpublished-bin/brace-extglob/bin/foo.js
+++ b/tests/fixtures/no-unpublished-bin/brace-extglob/bin/foo.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log("foo")

--- a/tests/fixtures/no-unpublished-bin/brace-extglob/bin/foo.test.js
+++ b/tests/fixtures/no-unpublished-bin/brace-extglob/bin/foo.test.js
@@ -1,0 +1,1 @@
+console.log("test")

--- a/tests/fixtures/no-unpublished-bin/brace-extglob/package.json
+++ b/tests/fixtures/no-unpublished-bin/brace-extglob/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "brace-extglob",
+    "version": "1.0.0",
+    "bin": {
+        "foo": "bin/foo.js"
+    },
+    "files": [
+        "{bin,src}/**/!(*.test).js"
+    ]
+}

--- a/tests/fixtures/no-unpublished/brace-extglob/index.js
+++ b/tests/fixtures/no-unpublished/brace-extglob/index.js
@@ -1,0 +1,1 @@
+require("./src/helper.js")

--- a/tests/fixtures/no-unpublished/brace-extglob/package.json
+++ b/tests/fixtures/no-unpublished/brace-extglob/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "brace-extglob",
+    "version": "1.0.0",
+    "main": "index.js",
+    "files": [
+        "{bin,src}/**/!(*.test).js"
+    ]
+}

--- a/tests/fixtures/no-unpublished/brace-extglob/src/helper.js
+++ b/tests/fixtures/no-unpublished/brace-extglob/src/helper.js
@@ -1,0 +1,1 @@
+module.exports = "published"

--- a/tests/fixtures/no-unpublished/brace-extglob/src/helper.test.js
+++ b/tests/fixtures/no-unpublished/brace-extglob/src/helper.test.js
@@ -1,0 +1,1 @@
+module.exports = "not published"

--- a/tests/fixtures/no-unpublished/brace-sequence/file1.js
+++ b/tests/fixtures/no-unpublished/brace-sequence/file1.js
@@ -1,0 +1,1 @@
+module.exports = "published"

--- a/tests/fixtures/no-unpublished/brace-sequence/index.js
+++ b/tests/fixtures/no-unpublished/brace-sequence/index.js
@@ -1,0 +1,1 @@
+require("./file1.js")

--- a/tests/fixtures/no-unpublished/brace-sequence/package.json
+++ b/tests/fixtures/no-unpublished/brace-sequence/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "brace-sequence",
+    "version": "1.0.0",
+    "main": "index.js",
+    "files": [
+        "file{1..3}.js"
+    ]
+}

--- a/tests/fixtures/no-unpublished/case-insensitive/Foo.js
+++ b/tests/fixtures/no-unpublished/case-insensitive/Foo.js
@@ -1,0 +1,1 @@
+module.exports = "published"

--- a/tests/fixtures/no-unpublished/case-insensitive/index.js
+++ b/tests/fixtures/no-unpublished/case-insensitive/index.js
@@ -1,0 +1,1 @@
+require("./Foo.js")

--- a/tests/fixtures/no-unpublished/case-insensitive/package.json
+++ b/tests/fixtures/no-unpublished/case-insensitive/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "case-insensitive",
+    "version": "1.0.0",
+    "main": "index.js",
+    "files": [
+        "{foo,bar}.js"
+    ]
+}

--- a/tests/fixtures/no-unpublished/extended-basename-exclusion/index.js
+++ b/tests/fixtures/no-unpublished/extended-basename-exclusion/index.js
@@ -1,0 +1,1 @@
+require("./src/test.js")

--- a/tests/fixtures/no-unpublished/extended-basename-exclusion/package.json
+++ b/tests/fixtures/no-unpublished/extended-basename-exclusion/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "extended-basename-exclusion",
+    "version": "1.0.0",
+    "main": "index.js",
+    "files": [
+        "src",
+        "!{test,spec}.js"
+    ]
+}

--- a/tests/fixtures/no-unpublished/extended-basename-exclusion/src/test.js
+++ b/tests/fixtures/no-unpublished/extended-basename-exclusion/src/test.js
@@ -1,0 +1,1 @@
+module.exports = "not published"

--- a/tests/lib/rules/no-unpublished-bin.js
+++ b/tests/lib/rules/no-unpublished-bin.js
@@ -70,6 +70,11 @@ new RuleTester().run("no-unpublished-bin", rule, {
             filename: fixture("issue115/lib/a.js"),
             code: "'issue115/lib/a.js'",
         },
+        // Brace expansion and extglob patterns in the files field.
+        {
+            filename: fixture("brace-extglob/bin/foo.js"),
+            code: "'brace-extglob/bin/foo.js'",
+        },
 
         // empty name
         "'stdin'",

--- a/tests/lib/rules/no-unpublished-require.js
+++ b/tests/lib/rules/no-unpublished-require.js
@@ -221,6 +221,12 @@ ruleTester.run("no-unpublished-require", rule, {
             code: "require('.');",
         },
 
+        // Brace expansion and extglob patterns in the files field.
+        {
+            filename: fixture("brace-extglob/index.js"),
+            code: "require('./src/helper.js');",
+        },
+
         // allowModules option
         {
             filename: fixture("1/test.js"),

--- a/tests/lib/rules/no-unpublished-require.js
+++ b/tests/lib/rules/no-unpublished-require.js
@@ -226,6 +226,16 @@ ruleTester.run("no-unpublished-require", rule, {
             filename: fixture("brace-extglob/index.js"),
             code: "require('./src/helper.js');",
         },
+        // npm's files matcher is case-insensitive.
+        {
+            filename: fixture("case-insensitive/index.js"),
+            code: "require('./Foo.js');",
+        },
+        // npm expands numeric brace sequences.
+        {
+            filename: fixture("brace-sequence/index.js"),
+            code: "require('./file1.js');",
+        },
 
         // allowModules option
         {
@@ -268,6 +278,18 @@ ruleTester.run("no-unpublished-require", rule, {
         },
     ],
     invalid: [
+        // The extglob fixture's test helper is omitted from the package.
+        {
+            filename: fixture("brace-extglob/index.js"),
+            code: "require('./src/helper.test.js');",
+            errors: ['"./src/helper.test.js" is not published.'],
+        },
+        // A basename-only extended exclusion applies below the package root.
+        {
+            filename: fixture("extended-basename-exclusion/index.js"),
+            code: "require('./src/test.js');",
+            errors: ['"./src/test.js" is not published.'],
+        },
         {
             filename: fixture("2/test.js"),
             code: "require('./ignore1.js');",


### PR DESCRIPTION
## Summary

- Support the brace expansion and extglob syntax accepted by npm in the package files field.
- Preserve the existing ignore matcher for ordinary patterns and reuse the existing globrex dependency for extended patterns.
- Add regressions covering both no-unpublished-bin and no-unpublished-require.

Fixes #555

## Validation

- Focused rule tests: 98 passing
- Full test suite: 3064 passing, 3 pending
- npm pack dry-run reproduction
- Type checks, JavaScript lint, docs lint, and git diff check

Assisted-by: OpenAI Codex. AI assistance was used for investigation, implementation, and test drafting; the submitted diff was reviewed and validated before publication.