### PR TITLE
fix: handle import.meta paths in no-path-concat

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,51 +106,51 @@ For [Shareable Configs](https://eslint.org/docs/latest/developer-guide/shareable
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
 ❌ Deprecated.
 
-| Name                                                                                         | Description                                                                 | 💼   | 🔧 | ❌  |
-| :------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------- | :--- | :- | :- |
-| [callback-return](docs/rules/callback-return.md)                                             | require `return` statements after callbacks                                 |      |    |    |
-| [exports-style](docs/rules/exports-style.md)                                                 | enforce either `module.exports` or `exports`                                |      | 🔧 |    |
-| [file-extension-in-import](docs/rules/file-extension-in-import.md)                           | enforce the style of file extensions in `import` declarations               |      | 🔧 |    |
-| [global-require](docs/rules/global-require.md)                                               | require `require()` calls to be placed at top-level module scope            |      |    |    |
-| [handle-callback-err](docs/rules/handle-callback-err.md)                                     | require error handling in callbacks                                         |      |    |    |
-| [hashbang](docs/rules/hashbang.md)                                                           | require correct usage of hashbang                                           | 🟢 ✅ | 🔧 |    |
-| [no-callback-literal](docs/rules/no-callback-literal.md)                                     | enforce Node.js-style error-first callback pattern is followed              |      |    |    |
-| [no-deprecated-api](docs/rules/no-deprecated-api.md)                                         | disallow deprecated APIs                                                    | 🟢 ✅ |    |    |
-| [no-exports-assign](docs/rules/no-exports-assign.md)                                         | disallow the assignment to `exports`                                        | 🟢 ✅ |    |    |
-| [no-extraneous-import](docs/rules/no-extraneous-import.md)                                   | disallow `import` declarations which import extraneous modules              | 🟢 ✅ |    |    |
-| [no-extraneous-require](docs/rules/no-extraneous-require.md)                                 | disallow `require()` expressions which import extraneous modules            | 🟢 ✅ |    |    |
-| [no-hide-core-modules](docs/rules/no-hide-core-modules.md)                                   | disallow third-party modules which are hiding core modules                  |      |    | ❌  |
-| [no-missing-import](docs/rules/no-missing-import.md)                                         | disallow `import` declarations which import missing modules                 | 🟢 ✅ |    |    |
-| [no-missing-require](docs/rules/no-missing-require.md)                                       | disallow `require()` expressions which import missing modules               | 🟢 ✅ |    |    |
-| [no-mixed-requires](docs/rules/no-mixed-requires.md)                                         | disallow `require` calls to be mixed with regular variable declarations     |      |    |    |
-| [no-new-require](docs/rules/no-new-require.md)                                               | disallow `new` operators with calls to `require`                            |      |    |    |
-| [no-path-concat](docs/rules/no-path-concat.md)                                               | disallow string concatenation with `__dirname` and `__filename`             |      |    |    |
-| [no-process-env](docs/rules/no-process-env.md)                                               | disallow the use of `process.env`                                           |      |    |    |
-| [no-process-exit](docs/rules/no-process-exit.md)                                             | disallow the use of `process.exit()`                                        | 🟢 ✅ |    |    |
-| [no-restricted-import](docs/rules/no-restricted-import.md)                                   | disallow specified modules when loaded by `import` declarations             |      |    |    |
-| [no-restricted-require](docs/rules/no-restricted-require.md)                                 | disallow specified modules when loaded by `require`                         |      |    |    |
-| [no-sync](docs/rules/no-sync.md)                                                             | disallow synchronous methods                                                |      |    |    |
-| [no-top-level-await](docs/rules/no-top-level-await.md)                                       | disallow top-level `await` in published modules                             |      |    |    |
-| [no-unpublished-bin](docs/rules/no-unpublished-bin.md)                                       | disallow `bin` files that npm ignores                                       |      |    |    |
-| [no-unpublished-import](docs/rules/no-unpublished-import.md)                                 | disallow `import` declarations which import private modules                 | 🟢 ✅ |    |    |
-| [no-unpublished-require](docs/rules/no-unpublished-require.md)                               | disallow `require()` expressions which import private modules               | 🟢 ✅ |    |    |
-| [no-unsupported-features/es-builtins](docs/rules/no-unsupported-features/es-builtins.md)     | disallow unsupported ECMAScript built-ins on the specified version          | 🟢 ✅ |    |    |
-| [no-unsupported-features/es-syntax](docs/rules/no-unsupported-features/es-syntax.md)         | disallow unsupported ECMAScript syntax on the specified version             | 🟢 ✅ |    |    |
-| [no-unsupported-features/node-builtins](docs/rules/no-unsupported-features/node-builtins.md) | disallow unsupported Node.js built-in APIs on the specified version         | 🟢 ✅ |    |    |
-| [prefer-global/buffer](docs/rules/prefer-global/buffer.md)                                   | enforce either `Buffer` or `require("buffer").Buffer`                       |      |    |    |
-| [prefer-global/console](docs/rules/prefer-global/console.md)                                 | enforce either `console` or `require("console")`                            |      |    |    |
-| [prefer-global/crypto](docs/rules/prefer-global/crypto.md)                                   | enforce either `crypto` or `require("crypto").webcrypto`                    |      |    |    |
-| [prefer-global/process](docs/rules/prefer-global/process.md)                                 | enforce either `process` or `require("process")`                            |      |    |    |
-| [prefer-global/text-decoder](docs/rules/prefer-global/text-decoder.md)                       | enforce either `TextDecoder` or `require("util").TextDecoder`               |      |    |    |
-| [prefer-global/text-encoder](docs/rules/prefer-global/text-encoder.md)                       | enforce either `TextEncoder` or `require("util").TextEncoder`               |      |    |    |
-| [prefer-global/timers](docs/rules/prefer-global/timers.md)                                   | enforce either global timer functions or `require("timers")`                |      |    |    |
-| [prefer-global/url](docs/rules/prefer-global/url.md)                                         | enforce either `URL` or `require("url").URL`                                |      |    |    |
-| [prefer-global/url-search-params](docs/rules/prefer-global/url-search-params.md)             | enforce either `URLSearchParams` or `require("url").URLSearchParams`        |      |    |    |
-| [prefer-node-protocol](docs/rules/prefer-node-protocol.md)                                   | enforce using the `node:` protocol when importing Node.js builtin modules.  |      | 🔧 |    |
-| [prefer-promises/dns](docs/rules/prefer-promises/dns.md)                                     | enforce `require("dns").promises`                                           |      |    |    |
-| [prefer-promises/fs](docs/rules/prefer-promises/fs.md)                                       | enforce `require("fs").promises`                                            |      |    |    |
-| [process-exit-as-throw](docs/rules/process-exit-as-throw.md)                                 | require that `process.exit()` expressions use the same code path as `throw` | 🟢 ✅ |    |    |
-| [shebang](docs/rules/shebang.md)                                                             | require correct usage of hashbang                                           |      | 🔧 | ❌  |
+| Name                                                                                         | Description                                                                           | 💼   | 🔧 | ❌  |
+| :------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------ | :--- | :- | :- |
+| [callback-return](docs/rules/callback-return.md)                                             | require `return` statements after callbacks                                           |      |    |    |
+| [exports-style](docs/rules/exports-style.md)                                                 | enforce either `module.exports` or `exports`                                          |      | 🔧 |    |
+| [file-extension-in-import](docs/rules/file-extension-in-import.md)                           | enforce the style of file extensions in `import` declarations                         |      | 🔧 |    |
+| [global-require](docs/rules/global-require.md)                                               | require `require()` calls to be placed at top-level module scope                      |      |    |    |
+| [handle-callback-err](docs/rules/handle-callback-err.md)                                     | require error handling in callbacks                                                   |      |    |    |
+| [hashbang](docs/rules/hashbang.md)                                                           | require correct usage of hashbang                                                     | 🟢 ✅ | 🔧 |    |
+| [no-callback-literal](docs/rules/no-callback-literal.md)                                     | enforce Node.js-style error-first callback pattern is followed                        |      |    |    |
+| [no-deprecated-api](docs/rules/no-deprecated-api.md)                                         | disallow deprecated APIs                                                              | 🟢 ✅ |    |    |
+| [no-exports-assign](docs/rules/no-exports-assign.md)                                         | disallow the assignment to `exports`                                                  | 🟢 ✅ |    |    |
+| [no-extraneous-import](docs/rules/no-extraneous-import.md)                                   | disallow `import` declarations which import extraneous modules                        | 🟢 ✅ |    |    |
+| [no-extraneous-require](docs/rules/no-extraneous-require.md)                                 | disallow `require()` expressions which import extraneous modules                      | 🟢 ✅ |    |    |
+| [no-hide-core-modules](docs/rules/no-hide-core-modules.md)                                   | disallow third-party modules which are hiding core modules                            |      |    | ❌  |
+| [no-missing-import](docs/rules/no-missing-import.md)                                         | disallow `import` declarations which import missing modules                           | 🟢 ✅ |    |    |
+| [no-missing-require](docs/rules/no-missing-require.md)                                       | disallow `require()` expressions which import missing modules                         | 🟢 ✅ |    |    |
+| [no-mixed-requires](docs/rules/no-mixed-requires.md)                                         | disallow `require` calls to be mixed with regular variable declarations               |      |    |    |
+| [no-new-require](docs/rules/no-new-require.md)                                               | disallow `new` operators with calls to `require`                                      |      |    |    |
+| [no-path-concat](docs/rules/no-path-concat.md)                                               | disallow string concatenation with `__dirname`, `__filename`, and `import.meta` paths |      |    |    |
+| [no-process-env](docs/rules/no-process-env.md)                                               | disallow the use of `process.env`                                                     |      |    |    |
+| [no-process-exit](docs/rules/no-process-exit.md)                                             | disallow the use of `process.exit()`                                                  | 🟢 ✅ |    |    |
+| [no-restricted-import](docs/rules/no-restricted-import.md)                                   | disallow specified modules when loaded by `import` declarations                       |      |    |    |
+| [no-restricted-require](docs/rules/no-restricted-require.md)                                 | disallow specified modules when loaded by `require`                                   |      |    |    |
+| [no-sync](docs/rules/no-sync.md)                                                             | disallow synchronous methods                                                          |      |    |    |
+| [no-top-level-await](docs/rules/no-top-level-await.md)                                       | disallow top-level `await` in published modules                                       |      |    |    |
+| [no-unpublished-bin](docs/rules/no-unpublished-bin.md)                                       | disallow `bin` files that npm ignores                                                 |      |    |    |
+| [no-unpublished-import](docs/rules/no-unpublished-import.md)                                 | disallow `import` declarations which import private modules                           | 🟢 ✅ |    |    |
+| [no-unpublished-require](docs/rules/no-unpublished-require.md)                               | disallow `require()` expressions which import private modules                         | 🟢 ✅ |    |    |
+| [no-unsupported-features/es-builtins](docs/rules/no-unsupported-features/es-builtins.md)     | disallow unsupported ECMAScript built-ins on the specified version                    | 🟢 ✅ |    |    |
+| [no-unsupported-features/es-syntax](docs/rules/no-unsupported-features/es-syntax.md)         | disallow unsupported ECMAScript syntax on the specified version                       | 🟢 ✅ |    |    |
+| [no-unsupported-features/node-builtins](docs/rules/no-unsupported-features/node-builtins.md) | disallow unsupported Node.js built-in APIs on the specified version                   | 🟢 ✅ |    |    |
+| [prefer-global/buffer](docs/rules/prefer-global/buffer.md)                                   | enforce either `Buffer` or `require("buffer").Buffer`                                 |      |    |    |
+| [prefer-global/console](docs/rules/prefer-global/console.md)                                 | enforce either `console` or `require("console")`                                      |      |    |    |
+| [prefer-global/crypto](docs/rules/prefer-global/crypto.md)                                   | enforce either `crypto` or `require("crypto").webcrypto`                              |      |    |    |
+| [prefer-global/process](docs/rules/prefer-global/process.md)                                 | enforce either `process` or `require("process")`                                      |      |    |    |
+| [prefer-global/text-decoder](docs/rules/prefer-global/text-decoder.md)                       | enforce either `TextDecoder` or `require("util").TextDecoder`                         |      |    |    |
+| [prefer-global/text-encoder](docs/rules/prefer-global/text-encoder.md)                       | enforce either `TextEncoder` or `require("util").TextEncoder`                         |      |    |    |
+| [prefer-global/timers](docs/rules/prefer-global/timers.md)                                   | enforce either global timer functions or `require("timers")`                          |      |    |    |
+| [prefer-global/url](docs/rules/prefer-global/url.md)                                         | enforce either `URL` or `require("url").URL`                                          |      |    |    |
+| [prefer-global/url-search-params](docs/rules/prefer-global/url-search-params.md)             | enforce either `URLSearchParams` or `require("url").URLSearchParams`                  |      |    |    |
+| [prefer-node-protocol](docs/rules/prefer-node-protocol.md)                                   | enforce using the `node:` protocol when importing Node.js builtin modules.            |      | 🔧 |    |
+| [prefer-promises/dns](docs/rules/prefer-promises/dns.md)                                     | enforce `require("dns").promises`                                                     |      |    |    |
+| [prefer-promises/fs](docs/rules/prefer-promises/fs.md)                                       | enforce `require("fs").promises`                                                      |      |    |    |
+| [process-exit-as-throw](docs/rules/process-exit-as-throw.md)                                 | require that `process.exit()` expressions use the same code path as `throw`           | 🟢 ✅ |    |    |
+| [shebang](docs/rules/shebang.md)                                                             | require correct usage of hashbang                                                     |      | 🔧 | ❌  |
 
 <!-- end auto-generated rules list -->
 

--- a/docs/rules/no-path-concat.md
+++ b/docs/rules/no-path-concat.md
@@ -1,10 +1,10 @@
 # n/no-path-concat
 
-📝 Disallow string concatenation with `__dirname` and `__filename`.
+📝 Disallow string concatenation with `__dirname`, `__filename`, and `import.meta` paths.
 
 <!-- end auto-generated rule header -->
 
-In Node.js, the `__dirname` and `__filename` global variables contain the directory path and the file path of the currently executing script file, respectively. Sometimes, developers try to use these variables to create paths to other files, such as:
+In Node.js, the `__dirname` and `__filename` global variables contain the directory path and the file path of the currently executing script file, respectively. In ES modules, `import.meta.dirname` and `import.meta.filename` provide the corresponding paths. Sometimes, developers try to use these values to create paths to other files, such as:
 
 ```js
 var fullPath = __dirname + "/foo.js";
@@ -26,9 +26,15 @@ var fullPath = path.resolve(__dirname, "foo.js");
 
 Both `path.join()` and `path.resolve()` are suitable replacements for string concatenation wherever file or directory paths are being created.
 
+`import.meta.url` is a URL string, not a file-system path. Use `new URL()` to resolve a relative URL instead of concatenating a path segment:
+
+```js
+const url = new URL("./foo.js", import.meta.url)
+```
+
 ## 📖 Rule Details
 
-This rule aims to prevent string concatenation of directory paths in Node.js
+This rule aims to prevent string concatenation of directory paths and URLs in Node.js.
 
 Examples of **incorrect** code for this rule:
 
@@ -39,6 +45,9 @@ const fullPath1 = __dirname + "/foo.js";
 const fullPath2 = __filename + "/foo.js";
 const fullPath3 = `${__dirname}/foo.js`;
 const fullPath4 = `${__filename}/foo.js`;
+const fullPath5 = import.meta.dirname + "/foo.js";
+const fullPath6 = import.meta.filename + "/foo.js";
+const fullUrl = import.meta.url + "/foo.js";
 ```
 
 Examples of **correct** code for this rule:
@@ -52,6 +61,9 @@ const fullPath3 = __dirname + ".js";
 const fullPath4 = __filename + ".map";
 const fullPath5 = `${__dirname}_foo.js`;
 const fullPath6 = `${__filename}.test.js`;
+const fullPath7 = path.join(import.meta.dirname, "foo.js");
+const fullPath8 = path.join(import.meta.filename, "foo.js");
+const fullUrl = new URL("./foo.js", import.meta.url);
 ```
 
 ## 🔎 Implementation

--- a/lib/rules/no-path-concat.js
+++ b/lib/rules/no-path-concat.js
@@ -146,7 +146,9 @@ function isImportMetaPath(node) {
         node.object.property.type === "Identifier" &&
         node.object.property.name === "meta" &&
         node.property.type === "Identifier" &&
-        (node.property.name === "dirname" || node.property.name === "filename")
+        (node.property.name === "dirname" ||
+            node.property.name === "filename" ||
+            node.property.name === "url")
     )
 }
 
@@ -197,7 +199,7 @@ export default {
         type: "suggestion",
         docs: {
             description:
-                "disallow string concatenation with `__dirname` and `__filename`",
+                "disallow string concatenation with `__dirname`, `__filename`, and `import.meta` paths",
             recommended: false,
             url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-path-concat.md",
         },
@@ -206,6 +208,7 @@ export default {
         messages: {
             usePathFunctions:
                 "Use path.join() or path.resolve() instead of string concatenation.",
+            useUrl: "Use new URL() instead of string concatenation.",
         },
     },
     create(context) {
@@ -247,7 +250,11 @@ export default {
                 if (isConcat(node, sepNodes, globalScope)) {
                     context.report({
                         node: node.parent,
-                        messageId: "usePathFunctions",
+                        messageId:
+                            node.property.type === "Identifier" &&
+                            node.property.name === "url"
+                                ? "useUrl"
+                                : "usePathFunctions",
                     })
                 }
             },

--- a/lib/rules/no-path-concat.js
+++ b/lib/rules/no-path-concat.js
@@ -133,22 +133,49 @@ function isPathSeparator(c) {
 }
 
 /**
+ * @param {import('estree').MemberExpression} node
+ * @returns {string | undefined}
+ */
+function getStaticPropertyName(node) {
+    if (!node.computed && node.property.type === "Identifier") {
+        return node.property.name
+    }
+    if (
+        node.computed &&
+        node.property.type === "Literal" &&
+        typeof node.property.value === "string"
+    ) {
+        return node.property.value
+    }
+    if (
+        node.computed &&
+        node.property.type === "TemplateLiteral" &&
+        node.property.expressions.length === 0
+    ) {
+        return node.property.quasis[0]?.value.cooked ?? undefined
+    }
+}
+
+/**
  * @param {import('estree').Node} node
  * @returns {node is import('estree').MemberExpression}
  */
 function isImportMetaPath(node) {
+    const propertyName =
+        node.type === "MemberExpression"
+            ? getStaticPropertyName(node)
+            : undefined
+
     return (
         node.type === "MemberExpression" &&
-        !node.computed &&
         node.object.type === "MetaProperty" &&
         node.object.meta.type === "Identifier" &&
         node.object.meta.name === "import" &&
         node.object.property.type === "Identifier" &&
         node.object.property.name === "meta" &&
-        node.property.type === "Identifier" &&
-        (node.property.name === "dirname" ||
-            node.property.name === "filename" ||
-            node.property.name === "url")
+        (propertyName === "dirname" ||
+            propertyName === "filename" ||
+            propertyName === "url")
     )
 }
 
@@ -251,8 +278,7 @@ export default {
                     context.report({
                         node: node.parent,
                         messageId:
-                            node.property.type === "Identifier" &&
-                            node.property.name === "url"
+                            getStaticPropertyName(node) === "url"
                                 ? "useUrl"
                                 : "usePathFunctions",
                     })

--- a/tests/lib/rules/no-path-concat.js
+++ b/tests/lib/rules/no-path-concat.js
@@ -24,6 +24,9 @@ new RuleTester({
         "var fullPath = `${__filename}.map`;",
         'var fullPath = __filename + (test ? ".js" : ".ts");',
         'var fullPath = __filename + (ext || ".js");',
+        'var fullPath = import.meta.dirname + ".map";',
+        'var fullPath = import.meta.filename + ".map";',
+        'var fullUrl = import.meta.url + ".map";',
     ],
 
     invalid: [
@@ -144,6 +147,30 @@ new RuleTester({
             errors: [
                 {
                     messageId: "usePathFunctions",
+                },
+            ],
+        },
+        {
+            code: 'var fullPath = import.meta.dirname + "/foo.js";',
+            errors: [
+                {
+                    messageId: "usePathFunctions",
+                },
+            ],
+        },
+        {
+            code: 'var fullPath = import.meta.filename + "/foo.js";',
+            errors: [
+                {
+                    messageId: "usePathFunctions",
+                },
+            ],
+        },
+        {
+            code: 'var fullUrl = import.meta.url + "/foo.js";',
+            errors: [
+                {
+                    messageId: "useUrl",
                 },
             ],
         },

--- a/tests/lib/rules/no-path-concat.js
+++ b/tests/lib/rules/no-path-concat.js
@@ -174,5 +174,21 @@ new RuleTester({
                 },
             ],
         },
+        {
+            code: 'var fullUrl = import.meta["url"] + "/foo.js";',
+            errors: [
+                {
+                    messageId: "useUrl",
+                },
+            ],
+        },
+        {
+            code: "var fullUrl = `${import.meta[`url`]}/foo.js`;",
+            errors: [
+                {
+                    messageId: "useUrl",
+                },
+            ],
+        },
     ],
 })


### PR DESCRIPTION
## Summary

- Extend `n/no-path-concat` to detect concatenation with `import.meta.dirname`, `import.meta.filename`, and `import.meta.url`.
- Recommend `path.join()` or `path.resolve()` for file-system paths and `new URL()` for `import.meta.url`.
- Add rule regressions and regenerate the rule documentation table.

Fixes #295.

## Validation

- `npm run test:mocha -- tests/lib/rules/no-path-concat.js`
- `npm test`

Both pass locally (`31` focused tests; `3068` full tests, `3` pending).

Assisted-by: OpenAI Codex. The contributor reviewed the implementation and validation before publication.
