### PR TITLE
fix(no-unsupported-features): classify util.styleText as experimental

### DIFF
--- a/lib/unsupported-features/node-builtins-modules/util.js
+++ b/lib/unsupported-features/node-builtins-modules/util.js
@@ -126,7 +126,10 @@ const util = {
     setTraceSigInt: { [READ]: { supported: ["22.19.0", "24.6.0"] } },
     stripVTControlCharacters: { [READ]: { supported: ["16.11.0"] } },
     styleText: {
-        [READ]: { supported: ["20.12.0", "21.7.0", "22.13.0", "23.5.0"] },
+        [READ]: {
+            experimental: ["20.12.0", "21.7.0"],
+            supported: ["22.13.0", "23.5.0"],
+        },
     },
     toUSVString: { [READ]: { supported: ["16.8.0", "14.18.0"] } },
     transferableAbortController: {

--- a/tests/lib/rules/no-unsupported-features/node-builtins.js
+++ b/tests/lib/rules/no-unsupported-features/node-builtins.js
@@ -4528,6 +4528,14 @@ new RuleTester({ languageOptions: { sourceType: "module" } }).run(
                     code: "require('util').types",
                     options: [{ version: "10.0.0" }],
                 },
+                {
+                    code: "require('util').styleText",
+                    options: [{ version: "21.7.0", allowExperimental: true }],
+                },
+                {
+                    code: "import { styleText } from 'node:util'; styleText('green', 'ok')",
+                    options: [{ version: "21.7.0", allowExperimental: true }],
+                },
 
                 // Ignores
                 {
@@ -4818,6 +4826,34 @@ new RuleTester({ languageOptions: { sourceType: "module" } }).run(
                                 name: "util.types",
                                 supported: "10.0.0",
                                 version: "9.9.9",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code: "require('util').styleText",
+                    options: [{ version: "21.7.0" }],
+                    errors: [
+                        {
+                            messageId: "not-supported-till",
+                            data: {
+                                name: "util.styleText",
+                                supported: "23.5.0 (backported: ^22.13.0)",
+                                version: "21.7.0",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code: "require('util').styleText",
+                    options: [{ version: "20.11.0", allowExperimental: true }],
+                    errors: [
+                        {
+                            messageId: "not-experimental-till",
+                            data: {
+                                name: "util.styleText",
+                                experimental: "21.7.0 (backported: ^20.12.0)",
+                                version: "20.11.0",
                             },
                         },
                     ],


### PR DESCRIPTION
## Summary

- classify `util.styleText` as experimental from Node 20.12.0 / 21.7.0 until it became stable in 22.13.0 / 23.5.0
- add coverage for `allowExperimental` and both diagnostic version boundaries
- cover the issue’s `import { styleText } from 'node:util'` form

Fixes #557.

Node’s documentation lists `util.styleText` as added in v20.12.0/v21.7.0 and stable in v22.13.0/v23.5.0. The related `mock.property()` metadata already matches its documented supported releases, so this patch deliberately leaves it unchanged.

## Validation

- `npm run test:mocha -- tests/lib/rules/no-unsupported-features/node-builtins.js` (704 passing)
- ESLint on changed files
- Prettier check on changed files
- `git diff --check`

## AI assistance

This PR was prepared with AI assistance. The metadata change and regression tests were independently reviewed against the Node.js API history and the rule’s existing version-diagnostic contracts.
