### PR TITLE
docs: add eslint-plugin-node migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Additional ESLint rules for Node.js
 npm install --save-dev eslint eslint-plugin-n
 ```
 
+Migrating from `eslint-plugin-node`? See the [migration guide](docs/migration.md).
+
 | Version | Supported Node.js | Supported ESLint Version | Status |
 |---------|-------------------|---------------------------|--------|
 | 18.x   | `^20.19.0 \|\| ^22.13.0 \|\| >=24.0.0`  | `>=8.57.1`          | 🏃‍♂️actively maintained |

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,63 @@
+# Migrating from eslint-plugin-node
+
+`eslint-plugin-n` is the maintained fork of `eslint-plugin-node`. The rule options are compatible, so most migrations only need to change the package name and the plugin prefix.
+
+## Install
+
+Remove the unmaintained package and install the maintained fork:
+
+```sh
+npm uninstall eslint-plugin-node
+npm install --save-dev eslint-plugin-n
+```
+
+## Configuration
+
+For a legacy `.eslintrc.*` configuration, change the plugin name and the `extends` entry:
+
+```jsonc
+{
+    "plugins": ["n"],
+    "extends": ["plugin:n/recommended"]
+}
+```
+
+The other legacy recommended configurations use the same replacement:
+
+| Before                           | After                         |
+| -------------------------------- | ----------------------------- |
+| `plugin:node/recommended`        | `plugin:n/recommended`        |
+| `plugin:node/recommended-module` | `plugin:n/recommended-module` |
+| `plugin:node/recommended-script` | `plugin:n/recommended-script` |
+
+For a flat `eslint.config.js`, import the fork and register it under the `n` plugin name:
+
+```js
+import n from "eslint-plugin-n"
+import { defineConfig } from "eslint/config"
+
+export default defineConfig([
+    {
+        plugins: { n },
+        extends: ["n/recommended-module"]
+    }
+])
+```
+
+## Rule names and disable comments
+
+Replace the `node/` prefix with `n/` wherever a rule is referenced. Rule options do not need to change:
+
+```diff
+- "node/no-deprecated-api": "error"
++ "n/no-deprecated-api": "error"
+```
+
+The same replacement applies to inline configuration comments:
+
+```diff
+- /* eslint node/no-deprecated-api: "error" */
++ /* eslint n/no-deprecated-api: "error" */
+```
+
+Existing shared settings under the `node` name continue to work for backward compatibility. New configurations may use the `n` name instead.


### PR DESCRIPTION
## Summary

- Add a migration guide for users moving from `eslint-plugin-node` to `eslint-plugin-n`.
- Document package, legacy and flat-config, rule-prefix, inline-comment, and shared-settings changes.
- Link the guide from the README.

Closes #178

Validation: markdownlint passes for the README and guide; Prettier and `git diff --check` pass.

AI assistance: OpenAI Codex assisted with the implementation and validation; the contributor reviewed the final diff and current configuration semantics.