### PR TITLE
docs: update outdated http links to https in docs/rules

### DIFF
--- a/docs/rules/no-unsupported-features/es-builtins.md
+++ b/docs/rules/no-unsupported-features/es-builtins.md
@@ -136,7 +136,7 @@ The `"ignores"` option accepts an array of the following strings.
 
 ### Shared Settings
 
-The following options can be set by [shared settings](http://eslint.org/docs/user-guide/configuring.html#adding-shared-settings).
+The following options can be set by [shared settings](https://eslint.org/docs/latest/use/configure/configuration-files#configuring-shared-settings).
 Several rules have the same option, but we can set this option at once.
 
 - `version`

--- a/docs/rules/no-unsupported-features/es-syntax.md
+++ b/docs/rules/no-unsupported-features/es-syntax.md
@@ -114,7 +114,7 @@ The `"ignores"` option accepts an array of the following strings.
 
 ### Shared Settings
 
-The following options can be set by [shared settings](http://eslint.org/docs/user-guide/configuring.html#adding-shared-settings).
+The following options can be set by [shared settings](https://eslint.org/docs/latest/use/configure/configuration-files#configuring-shared-settings).
 Several rules have the same option, but we can set this option at once.
 
 - `version`

--- a/docs/rules/no-unsupported-features/node-builtins.md
+++ b/docs/rules/no-unsupported-features/node-builtins.md
@@ -65,7 +65,7 @@ The `"ignores"` option accepts an array of strings.
 
 ### Shared Settings
 
-The following options can be set by [shared settings](http://eslint.org/docs/user-guide/configuring.html#adding-shared-settings).
+The following options can be set by [shared settings](https://eslint.org/docs/latest/use/configure/configuration-files#configuring-shared-settings).
 Several rules have the same option, but we can set this option at once.
 
 - `version`

--- a/docs/rules/process-exit-as-throw.md
+++ b/docs/rules/process-exit-as-throw.md
@@ -30,9 +30,9 @@ This rule itself never warn code.
 - [no-fallthrough]
 - [no-unreachable]
 
-[consistent-return]: http://eslint.org/docs/rules/consistent-return
-[no-fallthrough]: http://eslint.org/docs/rules/no-fallthrough
-[no-unreachable]: http://eslint.org/docs/rules/no-unreachable
+[consistent-return]: https://eslint.org/docs/latest/rules/consistent-return
+[no-fallthrough]: https://eslint.org/docs/latest/rules/no-fallthrough
+[no-unreachable]: https://eslint.org/docs/latest/rules/no-unreachable
 
 ## 🔎 Implementation
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint Community adheres to the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?
Fix outdated/dead `http://` links in `docs/rules` and update them to `https://`, using each link's actual current destination instead of just swapping the protocol.

#### What changes did you make? (Give an overview)
- `docs/rules/no-unsupported-features/es-builtins.md`, `es-syntax.md`, `node-builtins.md`: the "shared settings" link pointed to `http://eslint.org/docs/user-guide/configuring.html#adding-shared-settings`, which now 404s after eslint.org's docs restructure. Updated to the current page: `https://eslint.org/docs/latest/use/configure/configuration-files#configuring-shared-settings`.
- `docs/rules/process-exit-as-throw.md`: the `consistent-return`, `no-fallthrough`, and `no-unreachable` reference links used the old `/docs/rules/...` path, which now redirects to `/docs/latest/rules/...`. Updated to the final destination to avoid the unnecessary redirect.

I verified each link with `curl -L` before changing anything, and ran `npm test` locally — all checks pass.


#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->
N/A — no existing issue in this repository covers this; confirmed by searching both open and closed issues/PRs for "http", "https", and "link".


#### Is there anything you'd like reviewers to focus on?
Note: left a few other `http://` occurrences untouched (author link in `no-sync.js` that now redirects elsewhere, and a test fixture string in `no-missing-import.js`) since they aren't real links to fix.

