### PR TITLE
feat: add require-assert-message rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ For [Shareable Configs](https://eslint.org/docs/latest/developer-guide/shareable
 | [prefer-promises/dns](docs/rules/prefer-promises/dns.md)                                     | enforce `require("dns").promises`                                                     |      |    |    |
 | [prefer-promises/fs](docs/rules/prefer-promises/fs.md)                                       | enforce `require("fs").promises`                                                      |      |    |    |
 | [process-exit-as-throw](docs/rules/process-exit-as-throw.md)                                 | require that `process.exit()` expressions use the same code path as `throw`           | 🟢 ✅ |    |    |
+| [require-assert-message](docs/rules/require-assert-message.md)                               | require messages for `node:assert` calls                                              |      |    |    |
 | [shebang](docs/rules/shebang.md)                                                             | require correct usage of hashbang                                                     |      | 🔧 | ❌  |
 
 <!-- end auto-generated rules list -->

--- a/docs/rules/require-assert-message.md
+++ b/docs/rules/require-assert-message.md
@@ -1,0 +1,44 @@
+# n/require-assert-message
+
+📝 Require messages for `node:assert` calls.
+
+<!-- end auto-generated rule header -->
+
+Node.js assertion errors are easier to understand when the assertion provides an explanation. This rule requires a non-empty message for `node:assert` and `node:assert/strict` calls whose message position is unambiguous. It also supports the `strict` export from `node:assert`.
+
+## 📖 Rule Details
+
+Examples of 👍 **correct** code for this rule:
+
+```js
+/*eslint n/require-assert-message: "error" */
+
+import assert from "node:assert/strict";
+
+assert.ok(user, "user is required");
+assert.equal(user.role, "admin", "user must be an administrator");
+assert.match(name, /^[a-z]+$/u, "name must contain lowercase letters only");
+```
+
+Examples of 👎 **incorrect** code for this rule:
+
+```js
+/*eslint n/require-assert-message: "error" */
+
+import assert from "node:assert/strict";
+
+assert.ok(user);
+assert.equal(user.role, "admin", undefined);
+assert.match(name, /^[a-z]+$/u, "");
+```
+
+The rule checks `assert()`, `assert.ok()`, equality assertions, `match()`, `doesNotMatch()`, and `partialDeepStrictEqual()`.
+
+It does not check `throws()`, `doesNotThrow()`, `rejects()`, or `doesNotReject()` because their optional error parameter makes the position of a message ambiguous. It also does not check `ifError()`, which has no message parameter, or `fail()`, which is commonly used to mark unreachable code.
+
+To avoid false positives, the rule does not report calls through an assertion binding that is reassigned after it is imported or required.
+
+## 🔎 Implementation
+
+- [Rule source](../../lib/rules/require-assert-message.js)
+- [Test source](../../tests/lib/rules/require-assert-message.js)

--- a/lib/all-rules.js
+++ b/lib/all-rules.js
@@ -41,6 +41,7 @@ import preferGlobalUrlSearchParams from "./rules/prefer-global/url-search-params
 import preferGlobalUrl from "./rules/prefer-global/url.js"
 import preferGlobalTimers from "./rules/prefer-global/timers.js"
 import preferImportAssertStrict from "./rules/prefer-import/assert-strict.js"
+import requireAssertMessage from "./rules/require-assert-message.js"
 import preferNodeProtocol from "./rules/prefer-node-protocol.js"
 import preferProcessGetBuiltinModule from "./rules/prefer-process-get-builtin-module.js"
 import preferPromisesDns from "./rules/prefer-promises/dns.js"
@@ -89,6 +90,7 @@ const allRules = {
     "prefer-global/url": preferGlobalUrl,
     "prefer-global/timers": preferGlobalTimers,
     "prefer-import/assert-strict": preferImportAssertStrict,
+    "require-assert-message": requireAssertMessage,
     "prefer-node-protocol": preferNodeProtocol,
     "prefer-process-get-builtin-module": preferProcessGetBuiltinModule,
     "prefer-promises/dns": preferPromisesDns,

--- a/lib/rules/require-assert-message.js
+++ b/lib/rules/require-assert-message.js
@@ -1,0 +1,152 @@
+/**
+ * @author electrohyun
+ * See LICENSE file in root directory for full license.
+ */
+
+import {
+    CALL,
+    findVariable,
+    ReferenceTracker,
+} from "@eslint-community/eslint-utils"
+
+/** @type {import('@eslint-community/eslint-utils').TraceMap<number>} */
+const assertTraceMap = {
+    [CALL]: 1,
+    ok: { [CALL]: 1 },
+    equal: { [CALL]: 2 },
+    notEqual: { [CALL]: 2 },
+    deepEqual: { [CALL]: 2 },
+    notDeepEqual: { [CALL]: 2 },
+    strictEqual: { [CALL]: 2 },
+    notStrictEqual: { [CALL]: 2 },
+    deepStrictEqual: { [CALL]: 2 },
+    notDeepStrictEqual: { [CALL]: 2 },
+    match: { [CALL]: 2 },
+    doesNotMatch: { [CALL]: 2 },
+    partialDeepStrictEqual: { [CALL]: 2 },
+}
+
+/** @type {import('@eslint-community/eslint-utils').TraceMap<number>} */
+const traceMap = {
+    "node:assert": {
+        ...assertTraceMap,
+        strict: assertTraceMap,
+    },
+    "node:assert/strict": assertTraceMap,
+}
+
+/**
+ * @param {import('estree').Expression | import('estree').SpreadElement} node
+ * @returns {boolean}
+ */
+function isEmptyString(node) {
+    return (
+        (node.type === "Literal" && node.value === "") ||
+        (node.type === "TemplateLiteral" &&
+            node.expressions.length === 0 &&
+            node.quasis[0]?.value.cooked === "")
+    )
+}
+
+/**
+ * @param {import('estree').Expression | import('estree').SpreadElement} node
+ * @param {import('eslint').Rule.RuleContext} context
+ * @returns {boolean}
+ */
+function isUndefined(node, context) {
+    if (node.type === "UnaryExpression" && node.operator === "void") {
+        return true
+    }
+
+    if (node.type !== "Identifier" || node.name !== "undefined") {
+        return false
+    }
+
+    const variable = findVariable(context.sourceCode.getScope(node), node)
+
+    return variable?.defs.length === 0
+}
+
+/**
+ * @param {import('estree').CallExpression} node
+ * @param {import('eslint').Rule.RuleContext} context
+ * @returns {boolean}
+ */
+function isModifiedCallee(node, context) {
+    let callee = node.callee
+
+    while (callee.type === "MemberExpression") {
+        callee = callee.object
+    }
+
+    if (callee.type !== "Identifier") {
+        return false
+    }
+
+    const variable = findVariable(context.sourceCode.getScope(callee), callee)
+
+    return (
+        variable?.references.some(
+            reference => reference.isWrite() && !reference.init
+        ) ?? false
+    )
+}
+
+/** @type {import('./rule-module.js').RuleModule} */
+export default {
+    meta: {
+        docs: {
+            description: "require messages for `node:assert` calls",
+            recommended: false,
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/require-assert-message.md",
+        },
+        messages: {
+            emptyMessage: "The assertion message must not be empty.",
+            missingMessage: "Provide an assertion message.",
+        },
+        schema: [],
+        type: "suggestion",
+    },
+    create(context) {
+        return {
+            "Program:exit"() {
+                const scope = context.sourceCode.getScope(
+                    context.sourceCode.ast
+                )
+                const tracker = new ReferenceTracker(scope, { mode: "legacy" })
+                const references = [
+                    ...tracker.iterateCjsReferences(traceMap),
+                    ...tracker.iterateEsmReferences(traceMap),
+                ]
+
+                for (const {
+                    info: messageIndex,
+                    node: reference,
+                } of references) {
+                    const node =
+                        /** @type {import('estree').CallExpression} */ (
+                            reference
+                        )
+
+                    if (isModifiedCallee(node, context)) {
+                        continue
+                    }
+
+                    const message = node.arguments[messageIndex]
+
+                    if (message == null) {
+                        context.report({ node, messageId: "missingMessage" })
+                    } else if (
+                        isUndefined(message, context) ||
+                        isEmptyString(message)
+                    ) {
+                        context.report({
+                            node: message,
+                            messageId: "emptyMessage",
+                        })
+                    }
+                }
+            },
+        }
+    },
+}

--- a/tests/lib/rules/require-assert-message.js
+++ b/tests/lib/rules/require-assert-message.js
@@ -1,0 +1,118 @@
+/**
+ * @author electrohyun
+ * See LICENSE file in root directory for full license.
+ */
+
+import { RuleTester } from "#test-helpers"
+import rule from "../../../lib/rules/require-assert-message.js"
+
+new RuleTester({
+    languageOptions: {
+        ecmaVersion: 2022,
+        sourceType: "module",
+    },
+}).run("require-assert-message", rule, {
+    valid: [
+        'import assert from "node:assert"; assert(true, "expected true");',
+        'import * as assert from "node:assert/strict"; assert.ok(user, "user is required");',
+        'import { equal as assertEqual } from "node:assert"; assertEqual(actual, expected, "values must match");',
+        'const assert = require("node:assert"); assert.strictEqual(actual, expected, "values must match");',
+        'const { deepStrictEqual } = require("node:assert/strict"); deepStrictEqual(actual, expected, "values must match");',
+        'import assert from "assert"; assert.ok(user);',
+        'import assert from "node:assert"; assert.throws(fn);',
+        'import assert from "node:assert"; assert.doesNotThrow(fn);',
+        'import assert from "node:assert"; assert.rejects(asyncFn);',
+        'import assert from "node:assert"; assert.doesNotReject(asyncFn);',
+        'import assert from "node:assert"; assert.ifError(error);',
+        'import assert from "node:assert"; assert.fail();',
+        'import assert from "node:assert"; assert.ok(user, message);',
+        'import assert from "node:assert"; assert.ok(user, getMessage());',
+        'let assert = require("node:assert"); assert = mock; assert.ok(user);',
+        {
+            code: 'import assert from "node:assert"; function check(undefined) { assert.ok(user, undefined); }',
+        },
+        'import assert from "node:assert"; assert[method](user);',
+        'import("node:assert").then(assert => assert.ok(user));',
+        "function assert() {} assert();",
+    ],
+    invalid: [
+        {
+            code: 'import assert from "node:assert";\nassert(true);',
+            errors: [
+                {
+                    column: 1,
+                    endColumn: 13,
+                    endLine: 2,
+                    line: 2,
+                    messageId: "missingMessage",
+                },
+            ],
+        },
+        {
+            code: 'import assert from "node:assert/strict"; assert.ok(user);',
+            errors: [{ messageId: "missingMessage" }],
+        },
+        {
+            code: 'import { equal } from "node:assert"; equal(actual, expected);',
+            errors: [{ messageId: "missingMessage" }],
+        },
+        {
+            code: 'const { strictEqual } = require("node:assert/strict"); strictEqual(actual, expected);',
+            errors: [{ messageId: "missingMessage" }],
+            languageOptions: { sourceType: "commonjs" },
+        },
+        {
+            code: 'import { strict as assert } from "node:assert"; assert.ok(user);',
+            errors: [{ messageId: "missingMessage" }],
+        },
+        {
+            code: 'const assert = require("node:assert").strict; assert.ok(user);',
+            errors: [{ messageId: "missingMessage" }],
+            languageOptions: { sourceType: "commonjs" },
+        },
+        {
+            code: 'const { strict } = require("node:assert"); strict.ok(user);',
+            errors: [{ messageId: "missingMessage" }],
+            languageOptions: { sourceType: "commonjs" },
+        },
+        {
+            code: 'const { strict: assert } = require("node:assert"); assert.ok(user);',
+            errors: [{ messageId: "missingMessage" }],
+            languageOptions: { sourceType: "commonjs" },
+        },
+        {
+            code: `
+                import assert from "node:assert";
+                assert.notEqual(actual, expected);
+                assert.deepEqual(actual, expected);
+                assert.notDeepEqual(actual, expected);
+                assert.strictEqual(actual, expected);
+                assert.notStrictEqual(actual, expected);
+                assert.deepStrictEqual(actual, expected);
+                assert.notDeepStrictEqual(actual, expected);
+                assert.match(value, pattern);
+                assert.doesNotMatch(value, pattern);
+                assert.partialDeepStrictEqual(actual, expected);
+            `,
+            errors: Array.from({ length: 10 }, () => ({
+                messageId: "missingMessage",
+            })),
+        },
+        {
+            code: 'import assert from "node:assert"; assert.ok(user, undefined);',
+            errors: [{ messageId: "emptyMessage" }],
+        },
+        {
+            code: 'import assert from "node:assert"; assert.ok(user, void 0);',
+            errors: [{ messageId: "emptyMessage" }],
+        },
+        {
+            code: 'import assert from "node:assert"; assert.ok(user, "");',
+            errors: [{ messageId: "emptyMessage" }],
+        },
+        {
+            code: "import assert from 'node:assert'; assert.ok(user, ``);",
+            errors: [{ messageId: "emptyMessage" }],
+        },
+    ],
+})


### PR DESCRIPTION
Disclosure: I'm a participant of [open source contribution program OSSCA](https://github.com/eslint-ossca)

<!--
    Thank you for contributing!

    ESLint Community adheres to the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

> [!IMPORTANT]
> This PR currently supports only `node:assert` and `node:assert/strict`; bare `assert` and `assert/strict` specifiers are not supported.
> I would appreciate feedback on whether this scope is appropriate before merging.
>
> To avoid false positives, the rule conservatively skips all calls through a CommonJS assertion binding if that binding is reassigned after initialization. This can also skip calls that appear before the reassignment. It does not currently exclude property mutations such as `assert.ok = mock`.

#### What is the purpose of this pull request?

This PR adds `n/require-assert-message`, a rule that requires messages for Node.js `assert` calls.

Without a message, assertion failures fall back to Node.js's default `AssertionError` message, which can make the reason for a failure harder to identify. The rule reports missing or obviously empty messages for assertion APIs whose message position can be determined statically.

#### What changes did you make? (Give an overview)

- Added `n/require-assert-message`.
  - Tracks `node:assert`, `node:assert/strict`, and the `strict` export from `node:assert`.
  - Checks `assert()`, `assert.ok()`, equality assertions, `match()`, `doesNotMatch()`, and `partialDeepStrictEqual()`.
  - Reports a missing message, global `undefined`, a `void` expression, an empty string, and an empty template literal.
- Excluded `throws`, `doesNotThrow`, `rejects`, and `doesNotReject` because their optional `error` argument makes the message position ambiguous.
- Excluded `ifError`, which has no message parameter, and `fail`, which is commonly used to mark unreachable code.
- To avoid false positives, conservatively skips all calls through a CommonJS assertion binding if that binding is reassigned after initialization. This can also skip calls that appear before the reassignment.
- Added rule tests and documentation, and updated the generated rule list in the README.

Validation:

- `npm test`: 3178 passing, 3 pending
- JavaScript linting, Markdown linting, type checking, and generated-document checks pass

#### Related Issues

refs #322

#### Is there anything you'd like reviewers to focus on?

1. Bare specifier scope

- The rule currently supports only `node:assert` and `node:assert/strict`. Should it also support bare `assert` and `assert/strict` specifiers to align with existing plugin rules?

2. Property mutation policy

- Reassigned bindings are excluded:

   ```js
   let assert = require("node:assert");
   assert = mock;
   assert.ok(user); // Not reported.
   ```

- The current binding-reassignment policy is intentionally conservative and may also create false negatives for calls before the reassignment.

- However, property mutations are not currently excluded:

   ```js
   const assert = require("node:assert");
   assert.ok = mock;
   assert.ok(user); // May still be reported.
   ```

- This is an uncommon case. Please let me know whether it should also be excluded, or whether limiting the rule to binding reassignment is the right scope.